### PR TITLE
Implement DHCP log processing pipeline

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -1,0 +1,6 @@
+paths:
+  # Directory containing raw DHCP CSV files
+  raw_dhcp: data/raw/dhcp
+  # Location for the normalized interim CSV output
+  interim_dhcp: data/interim/dhcp.csv
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "harvester-prime"
+version = "0.1.0"
+description = "Utilities for processing DHCP log files"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "PyYAML>=6.0",
+]
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+

--- a/scripts/process.py
+++ b/scripts/process.py
@@ -1,0 +1,43 @@
+"""Script to process raw DHCP log files into a normalized CSV.
+
+This script reads configuration from ``configs/base.yaml`` to determine the
+locations of the raw DHCP logs and the destination for the normalized interim
+CSV file. The configuration allows these paths to be easily customised without
+modifying the code.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import yaml
+
+# Ensure the src directory is on the Python path
+BASE_DIR = Path(__file__).resolve().parent.parent
+sys.path.append(str(BASE_DIR / "src"))
+
+from app.collectors.files import load_dhcp_logs, write_dhcp_interim
+from app.processors.normalize import normalize_dhcp_records
+
+
+def load_config() -> dict:
+    """Load configuration values from ``configs/base.yaml``."""
+    config_path = BASE_DIR / "configs" / "base.yaml"
+    with open(config_path, encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def main() -> None:
+    config = load_config()
+    paths = config.get("paths", {})
+
+    raw_dir = BASE_DIR / paths.get("raw_dhcp", "data/raw/dhcp")
+    interim_file = BASE_DIR / paths.get("interim_dhcp", "data/interim/dhcp.csv")
+
+    records = load_dhcp_logs(raw_dir)
+    normalized = normalize_dhcp_records(records)
+    write_dhcp_interim(interim_file, normalized)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app/collectors/files.py
+++ b/src/app/collectors/files.py
@@ -1,0 +1,63 @@
+"""Utilities for working with CSV files."""
+from __future__ import annotations
+
+from pathlib import Path
+import csv
+from typing import Iterable, Dict, List
+
+# Columns we are interested in within DHCP log files
+DHCP_COLUMNS = [
+    "logSourceIdentifier",
+    "sourcMACAddress",
+    "payloadAsUTF",
+    "deviceTime",
+]
+
+
+def _is_valid_csv(path: Path) -> bool:
+    """Return True if *path* points to a CSV file we should process."""
+    return path.suffix == ".csv" and not path.name.endswith(".examples.csv")
+
+
+def list_csv_files(directory: Path) -> List[Path]:
+    """List all CSV files within *directory* that should be processed."""
+    directory = Path(directory)
+    return [p for p in directory.glob("*.csv") if _is_valid_csv(p)]
+
+
+def read_csv(path: Path, columns: Iterable[str] = DHCP_COLUMNS) -> List[Dict[str, str]]:
+    """Read selected *columns* from a CSV file.
+
+    Parameters
+    ----------
+    path:
+        Path to the CSV file.
+    columns:
+        Iterable with the names of the columns to return.
+    """
+    rows: List[Dict[str, str]] = []
+    with open(path, newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            rows.append({col: row.get(col, "") for col in columns})
+    return rows
+
+
+def load_dhcp_logs(directory: Path) -> List[Dict[str, str]]:
+    """Load and combine DHCP log entries from all CSV files in *directory*."""
+    logs: List[Dict[str, str]] = []
+    for file_path in list_csv_files(directory):
+        logs.extend(read_csv(file_path))
+    return logs
+
+
+def write_dhcp_interim(path: Path, rows: Iterable[Dict[str, str]]) -> None:
+    """Write normalized DHCP rows to *path* in CSV format."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = ["source", "ip", "mac", "hostname", "date"]
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)

--- a/src/app/processors/normalize.py
+++ b/src/app/processors/normalize.py
@@ -1,0 +1,53 @@
+"""Functions for normalizing DHCP log data."""
+from __future__ import annotations
+
+import re
+from typing import Dict, Iterable, List
+
+PAYLOAD_RE = re.compile(
+    r"assigned\s+(?P<ip>\d+\.\d+\.\d+\.\d+)\s+for\s+(?P<mac>[0-9A-Fa-f:]{17})(?:\s+(?P<hostname>[^\s]+))?"
+)
+
+
+def parse_payload(payload: str) -> Dict[str, str]:
+    """Extract IP, MAC and hostname from a payload string."""
+    match = PAYLOAD_RE.search(payload or "")
+    if not match:
+        return {"ip": "", "mac": "", "hostname": "unknown"}
+    info = match.groupdict()
+    if not info.get("hostname"):
+        info["hostname"] = "unknown"
+    return info
+
+
+def deduplicate_by_mac(records: Iterable[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Return only the latest record for each MAC address."""
+    latest: Dict[str, Dict[str, str]] = {}
+    for record in records:
+        mac = record.get("sourcMACAddress", "")
+        time_str = record.get("deviceTime", "0")
+        try:
+            timestamp = int(time_str)
+        except ValueError:
+            timestamp = 0
+        stored = latest.get(mac)
+        if stored is None or timestamp > int(stored.get("deviceTime", 0)):
+            latest[mac] = record
+    return list(latest.values())
+
+
+def normalize_dhcp_records(records: Iterable[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Normalize raw DHCP log records for downstream processing."""
+    normalized: List[Dict[str, str]] = []
+    for record in deduplicate_by_mac(records):
+        payload = parse_payload(record.get("payloadAsUTF", ""))
+        normalized.append(
+            {
+                "source": record.get("logSourceIdentifier", ""),
+                "ip": payload.get("ip", ""),
+                "mac": payload.get("mac", record.get("sourcMACAddress", "")),
+                "hostname": payload.get("hostname", "unknown"),
+                "date": record.get("deviceTime", ""),
+            }
+        )
+    return normalized


### PR DESCRIPTION
## Summary
- add CSV utilities for loading DHCP logs and writing normalized output
- normalize log records by parsing payloads and deduplicating MAC addresses
- provide a process script to run the end-to-end normalization to `data/interim/dhcp.csv`
- support configurable input/output paths via `configs/base.yaml`
- declare PyYAML dependency in `pyproject.toml`

## Testing
- `pytest -q`
- `python scripts/process.py` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install PyYAML` *(fails: Could not find a version that satisfies the requirement PyYAML)*


------
https://chatgpt.com/codex/tasks/task_e_689b568622108331bc19a2ec18997d4b