### PR TITLE
Add ARM CSV validation against DHCP data

### DIFF
--- a/scripts/process.py
+++ b/scripts/process.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import sys
 import csv
 from datetime import datetime
+import re
 
 import yaml
 
@@ -123,6 +124,101 @@ def run_validation(validation_dir: Path, dhcp_file: Path, report_file: Path) -> 
         writer.writerows(report_rows)
 
 
+MAC_RE = re.compile(r"^[0-9A-Fa-f]{2}([-:][0-9A-Fa-f]{2}){5}$")
+
+
+def run_arm_check(arm_dir: Path, dhcp_file: Path, report_file: Path) -> None:
+    """Generate ARM report from *arm_dir* against *dhcp_file*.
+
+    The report is written to *report_file* with columns ``name``, ``ipmac``,
+    ``owner`` and ``nate``. Rows are appended only if they are not already
+    present in the report.
+    """
+
+    arm_dir = Path(arm_dir)
+    dhcp_file = Path(dhcp_file)
+    report_file = Path(report_file)
+
+    if not dhcp_file.exists():
+        print(f"Відсутній файл DHCP {dhcp_file}. Крок перевірки ARM пропущено.")
+        return
+
+    # Load DHCP records indexed by normalized MAC
+    dhcp_records = {}
+    with open(dhcp_file, newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            mac = (row.get("mac", "") or "").upper().replace("-", ":")
+            dhcp_records[mac] = row
+
+    # Load existing MACs from the report to avoid duplicates
+    existing_macs = set()
+    if report_file.exists():
+        with open(report_file, newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                ipmac = row.get("ipmac", "")
+                if not ipmac:
+                    continue
+                parts = ipmac.splitlines()
+                if parts:
+                    existing_macs.add(parts[-1].strip().upper().replace("-", ":"))
+
+    matched_rows = []
+    unmatched_rows = []
+
+    if arm_dir.exists():
+        for path in list_csv_files(arm_dir):
+            with open(path, newline="", encoding="utf-8") as fh:
+                reader = csv.DictReader(fh)
+                for row in reader:
+                    mac_raw = row.get("MAC", "").strip()
+                    if not MAC_RE.fullmatch(mac_raw):
+                        continue
+                    mac = mac_raw.upper().replace("-", ":")
+                    if mac in existing_macs:
+                        continue
+                    hostname = row.get("Hostname", "")
+                    owner = row.get("Власник", "")
+                    type_pc = row.get("Тип ПК", "")
+                    dhcp_row = dhcp_records.get(mac)
+                    if dhcp_row:
+                        matched_rows.append(
+                            {
+                                "name": f"АРМ\n{hostname}",
+                                "ipmac": f"{dhcp_row.get('ip', '')}\n{mac}",
+                                "owner": owner,
+                                "nate": type_pc,
+                            }
+                        )
+                    else:
+                        unmatched_rows.append(
+                            {
+                                "name": f"АРМ\n{hostname}",
+                                "ipmac": f"-\n{mac}",
+                                "owner": owner,
+                                "nate": type_pc,
+                            }
+                        )
+                    existing_macs.add(mac)
+    else:
+        print(f"Відсутні файли для перевірки у {arm_dir}. Крок ARM пропущено.")
+
+    report_rows = matched_rows + unmatched_rows
+
+    if not report_rows:
+        return
+
+    report_file.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = ["name", "ipmac", "owner", "nate"]
+    mode = "a" if report_file.exists() else "w"
+    with open(report_file, mode, newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        if mode == "w":
+            writer.writeheader()
+        writer.writerows(report_rows)
+
+
 def main() -> None:
     config = load_config()
     paths = config.get("paths", {})
@@ -146,6 +242,10 @@ def main() -> None:
         print(
             f"Відсутні файли для валідації у {validation_dir}. Крок перевірки пропущено."
         )
+
+    arm_dir = BASE_DIR / "data" / "raw" / "arm"
+    report_file2 = BASE_DIR / "data" / "result" / "120report2.csv"
+    run_arm_check(arm_dir, interim_file, report_file2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `run_arm_check` to generate ARM report from `data/raw/arm` CSV files
- validate MAC addresses, match against `data/interim/dhcp.csv` and append to `data/result/120report2.csv`
- integrate ARM report generation into processing pipeline

## Testing
- `python -m py_compile scripts/process.py`
- `python -m pytest`
- `python scripts/process.py` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_689fabf5901483319530e679431ab035