### PR TITLE
Fix report column name and externalize paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,16 @@ python scripts/process.py
 The script reads configuration, processes the raw logs and stores the normalized output.
 
 See `src/app/collectors/files.py` for implementation details.
+
+## Configuration
+
+Directory and file locations used by the scripts can be adjusted in
+`configs/base.yaml`. The following keys are available:
+
+- `raw_dhcp`: directory containing raw DHCP logs.
+- `interim_dhcp`: path to the normalized interim CSV file.
+- `raw_validation`: directory with validation CSV files.
+- `validation_report`: report produced from the validation step.
+- `raw_arm`: directory with ARM inventory CSV files.
+- `raw_mkp`: directory with MKP inventory CSV files.
+- `arm_mkp_report`: report produced from ARM and MKP checks.

--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -3,4 +3,14 @@ paths:
   raw_dhcp: data/raw/dhcp
   # Location for the normalized interim CSV output
   interim_dhcp: data/interim/dhcp.csv
+  # Directory containing validation CSV files
+  raw_validation: data/raw/validation
+  # Report produced from the validation step
+  validation_report: data/result/report1.csv
+  # Directory with ARM inventory CSV files
+  raw_arm: data/raw/arm
+  # Directory with MKP inventory CSV files
+  raw_mkp: data/raw/mkp
+  # Report produced from ARM and MKP checks
+  arm_mkp_report: data/result/120report2.csv
 

--- a/scripts/process.py
+++ b/scripts/process.py
@@ -133,7 +133,7 @@ def run_arm_check(arm_dir: Path, dhcp_file: Path, report_file: Path) -> None:
     """Generate ARM report from *arm_dir* against *dhcp_file*.
 
     The report is written to *report_file* with columns ``name``, ``ipmac``,
-    ``owner`` and ``nate``. Rows are appended only if they are not already
+    ``owner`` and ``note``. Rows are appended only if they are not already
     present in the report.
     """
 
@@ -190,7 +190,7 @@ def run_arm_check(arm_dir: Path, dhcp_file: Path, report_file: Path) -> None:
                                 "name": f"АРМ\n{hostname}",
                                 "ipmac": f"{dhcp_row.get('ip', '')}\n{mac}",
                                 "owner": owner,
-                                "nate": type_pc,
+                                "note": type_pc,
                             }
                         )
                     else:
@@ -201,7 +201,7 @@ def run_arm_check(arm_dir: Path, dhcp_file: Path, report_file: Path) -> None:
                                 "name": f"АРМ\n{hostname}",
                                 "ipmac": ipmac,
                                 "owner": owner,
-                                "nate": type_pc,
+                                "note": type_pc,
                             }
                         )
                     existing_macs.add(mac)
@@ -214,7 +214,7 @@ def run_arm_check(arm_dir: Path, dhcp_file: Path, report_file: Path) -> None:
         return
 
     report_file.parent.mkdir(parents=True, exist_ok=True)
-    fieldnames = ["name", "ipmac", "owner", "nate"]
+    fieldnames = ["name", "ipmac", "owner", "note"]
     mode = "a" if report_file.exists() else "w"
     with open(report_file, mode, newline="", encoding="utf-8") as fh:
         writer = csv.DictWriter(fh, fieldnames=fieldnames)
@@ -227,7 +227,7 @@ def run_mkp_check(mkp_dir: Path, dhcp_file: Path, report_file: Path) -> None:
     """Generate MKP report from *mkp_dir* against *dhcp_file*.
 
     Rows are appended to *report_file* with columns ``name``, ``ipmac``,
-    ``owner`` and ``nate``. Existing entries are not duplicated.
+    ``owner`` and ``note``. Existing entries are not duplicated.
     """
 
     mkp_dir = Path(mkp_dir)
@@ -283,7 +283,7 @@ def run_mkp_check(mkp_dir: Path, dhcp_file: Path, report_file: Path) -> None:
                                 "name": f"МКП\n{model}",
                                 "ipmac": f"{dhcp_row.get('ip', '')}\n{mac}",
                                 "owner": owner,
-                                "nate": mkp_type,
+                                "note": mkp_type,
                             }
                         )
                     else:
@@ -292,7 +292,7 @@ def run_mkp_check(mkp_dir: Path, dhcp_file: Path, report_file: Path) -> None:
                                 "name": f"МКП\n{model}",
                                 "ipmac": mac,
                                 "owner": owner,
-                                "nate": mkp_type,
+                                "note": mkp_type,
                             }
                         )
                     existing_macs.add(mac)
@@ -305,7 +305,7 @@ def run_mkp_check(mkp_dir: Path, dhcp_file: Path, report_file: Path) -> None:
         return
 
     report_file.parent.mkdir(parents=True, exist_ok=True)
-    fieldnames = ["name", "ipmac", "owner", "nate"]
+    fieldnames = ["name", "ipmac", "owner", "note"]
     mode = "a" if report_file.exists() else "w"
     with open(report_file, mode, newline="", encoding="utf-8") as fh:
         writer = csv.DictWriter(fh, fieldnames=fieldnames)
@@ -329,20 +329,23 @@ def main() -> None:
     normalized = normalize_dhcp_records(records)
     write_dhcp_interim(interim_file, normalized)
 
-    validation_dir = BASE_DIR / "data" / "raw" / "validation"
+    validation_dir = BASE_DIR / paths.get("raw_validation", "data/raw/validation")
     if list_csv_files(validation_dir):
-        report_file = BASE_DIR / "data" / "result" / "report1.csv"
+        report_file = BASE_DIR / paths.get(
+            "validation_report", "data/result/report1.csv"
+        )
         run_validation(validation_dir, interim_file, report_file)
     else:
         print(
             f"Відсутні файли для валідації у {validation_dir}. Крок перевірки пропущено."
         )
 
-    arm_dir = BASE_DIR / "data" / "raw" / "arm"
-    report_file2 = BASE_DIR / "data" / "result" / "120report2.csv"
+    arm_dir = BASE_DIR / paths.get("raw_arm", "data/raw/arm")
+    mkp_dir = BASE_DIR / paths.get("raw_mkp", "data/raw/mkp")
+    report_file2 = BASE_DIR / paths.get(
+        "arm_mkp_report", "data/result/120report2.csv"
+    )
     run_arm_check(arm_dir, interim_file, report_file2)
-
-    mkp_dir = BASE_DIR / "data" / "raw" / "mkp"
     run_mkp_check(mkp_dir, interim_file, report_file2)
 
 


### PR DESCRIPTION
## Summary
- rename report field `nate` to `note`
- move hard-coded file paths into `configs/base.yaml`
- document configurable paths in README

## Testing
- `python -m py_compile scripts/process.py`
- `python scripts/process.py` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_689fb6cb6bd48331b9cb82d01afed393