### PR TITLE
refactor: centralize CSV column names

### DIFF
--- a/configs/schemas.yml
+++ b/configs/schemas.yml
@@ -1,0 +1,33 @@
+arm:
+  mac: "MAC"
+  hostname: "Hostname"
+  owner: "Власник"
+  pc_type: "Тип ПК"
+  ip: "IP"
+mkp:
+  mac: "Статичний MAC"
+  model: "Модель"
+  owner: "Відповідальний"
+  mkp_type: "Тип МКП"
+  randmac: "Динамічний MAC"
+dhcp:
+  mac: "mac"
+  hostname: "hostname"
+  ip: "ip"
+  firstDate: "firstDate"
+  lastDate: "lastDate"
+  source: "source"
+validation:
+  ip: "ip"
+  mac: "mac"
+report:
+  ipmac: "ipmac"
+verified:
+  mac: "mac"
+pending:
+  source: "source"
+  ip: "ip"
+  mac: "mac"
+  hostname: "hostname"
+  firstDate: "firstDate"
+  lastDate: "lastDate"


### PR DESCRIPTION
## Summary
- load CSV column schemas from new `configs/schemas.yml`
- map external CSV headers to canonical names in `scripts/process.py`
- add schema file containing all column name mappings

## Testing
- `python -m py_compile scripts/process.py`
- `pytest -q`
- `python scripts/process.py` *(fails: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68a218986af483318853d8ea528b7639