### PR TITLE
Add device type classification for pending devices

### DIFF
--- a/configs/device_type_rules.yml
+++ b/configs/device_type_rules.yml
@@ -1,0 +1,22 @@
+rules:
+  - type: arm
+    mode: prefix
+    patterns:
+      - "DESKTOP-"
+      - "LAPTOP-"
+
+  - type: mkp
+    mode: contains
+    patterns:
+      - "iPhone"
+      - "Tab-A9-"
+
+  - type: router
+    mode: regex
+    patterns:
+      - "^[gisy][0-9]{9}$"   # router може називатись g240427017, i123456789, s987654321, y000000001
+
+default: unknown
+options:
+  case_insensitive: true
+  trim: true

--- a/configs/schemas.yml
+++ b/configs/schemas.yml
@@ -25,6 +25,7 @@ report:
 verified:
   mac: "mac"
 pending:
+  type: "type"
   source: "source"
   ip: "ip"
   mac: "mac"

--- a/src/app/classifiers/device_type.py
+++ b/src/app/classifiers/device_type.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+from typing import Any
+
+import yaml
+
+
+class DeviceTypeClassifier:
+    """Classify device types based on hostname rules.
+
+    Parameters
+    ----------
+    rules_path:
+        Path to YAML file containing classification rules.
+    """
+
+    def __init__(self, rules_path: Path):
+        self.rules_path = Path(rules_path)
+        with open(self.rules_path, encoding="utf-8") as fh:
+            config: dict[str, Any] = yaml.safe_load(fh) or {}
+
+        self.default: str = config.get("default", "unknown")
+        options: dict[str, Any] = config.get("options", {})
+        self.case_insensitive: bool = bool(options.get("case_insensitive"))
+        self.trim: bool = bool(options.get("trim"))
+
+        self.rules: list[dict[str, Any]] = []
+        for rule in config.get("rules", []):
+            mode = rule.get("mode", "")
+            patterns = rule.get("patterns", []) or []
+            if mode == "regex":
+                flags = re.IGNORECASE if self.case_insensitive else 0
+                compiled = [re.compile(pat, flags) for pat in patterns]
+            else:
+                if self.case_insensitive:
+                    patterns = [pat.lower() for pat in patterns]
+                compiled = patterns
+            self.rules.append({"type": rule.get("type", self.default), "mode": mode, "patterns": compiled})
+
+    def classify(self, hostname: str | None) -> str:
+        """Return the device type for *hostname* based on loaded rules."""
+
+        if hostname is None:
+            hostname = ""
+        if self.trim:
+            hostname = hostname.strip()
+        cmp_hostname = hostname.lower() if self.case_insensitive else hostname
+
+        for rule in self.rules:
+            mode = rule["mode"]
+            patterns = rule["patterns"]
+            if mode == "regex":
+                for pattern in patterns:
+                    if pattern.search(hostname):
+                        return rule["type"]
+            elif mode == "prefix":
+                for pat in patterns:
+                    if cmp_hostname.startswith(pat):
+                        return rule["type"]
+            elif mode == "contains":
+                for pat in patterns:
+                    if pat in cmp_hostname:
+                        return rule["type"]
+        return self.default


### PR DESCRIPTION
## Summary
- classify devices in pending.csv via hostname-based rules
- load rules from new YAML config and map through DeviceTypeClassifier
- include type column schema for pending output

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install PyYAML` *(fails: Could not find a version that satisfies the requirement PyYAML)*

------
https://chatgpt.com/codex/tasks/task_e_68a21d6b25b083318ea1b66a422e3103