### PR TITLE
Normalize note column via local config

### DIFF
--- a/configs/local.example.yml
+++ b/configs/local.example.yml
@@ -1,0 +1,10 @@
+apps:
+  app1:
+    source: "офіс"
+    target: "Microsoft Office"
+  app2:
+    source: "хром"
+    target: "Google Chrome"
+  app3:
+    source: "СПЗ \"Кокос\""
+    target: "Antivirus \"KokoS\""


### PR DESCRIPTION
## Summary
- replace note values in verified.csv using case-insensitive mapping from configs/local.yml
- document local mapping format in configs/local.example.yml

## Testing
- `python -m pytest`
- `python -m py_compile scripts/process.py`
- `python - <<'PY' from scripts.process import normalize_note ... PY` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install PyYAML` *(fails: Could not find a version that satisfies the requirement PyYAML)*

------
https://chatgpt.com/codex/tasks/task_e_68a2300a4d088331ad6b62c236e96d27