### PR TITLE
Add verified column to report1 generation and schema

### DIFF
--- a/configs/schemas.yml
+++ b/configs/schemas.yml
@@ -24,6 +24,13 @@ report:
   ipmac: "ipmac"
 verified:
   mac: "mac"
+report1:
+  source: "source"
+  verified: "verified"
+  type: "type"
+  name: "name"
+  ipmac: "ipmac"
+  note: "note"
 pending:
   type: "type"
   source: "source"

--- a/data/interim/report1.example.csv
+++ b/data/interim/report1.example.csv
@@ -1,0 +1,4 @@
+source,verified,type,name,ipmac,note
+registry,true,arm,"АРМ
+Workstation01","192.168.1.10
+AA:BB:CC:DD:EE:FF","Надано на перевірку."

--- a/data/interim/verified.example.csv
+++ b/data/interim/verified.example.csv
@@ -1,0 +1,2 @@
+source,type,name,ip,mac,randmac,note
+registry,arm,Workstation01,192.168.1.10,AA:BB:CC:DD:EE:FF,,

--- a/scripts/generate_report1.py
+++ b/scripts/generate_report1.py
@@ -66,6 +66,7 @@ def build_report_rows(devices: list[tuple[str, str]], rows: list[dict[str, str]]
             report_rows.append(
                 {
                     "source": row.get("source", ""),
+                    "verified": "true",
                     "type": row.get("type", ""),
                     "name": name,
                     "ipmac": ipmac,
@@ -77,7 +78,7 @@ def build_report_rows(devices: list[tuple[str, str]], rows: list[dict[str, str]]
 
 def write_report(rows: list[dict[str, str]], path: Path) -> None:
     """Write rows to CSV at *path* with required columns."""
-    fieldnames = ["source", "type", "name", "ipmac", "note"]
+    fieldnames = ["source", "verified", "type", "name", "ipmac", "note"]
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w", newline="", encoding="utf-8") as fh:
         writer = csv.DictWriter(fh, fieldnames=fieldnames)


### PR DESCRIPTION
## Summary
- include `verified` column when generating `report1.csv`
- define `report1` schema with expected columns
- add example CSV files for verified devices and report1 format

## Testing
- `python -m py_compile scripts/generate_report1.py`
- `python scripts/generate_report1.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2dd361dcc833184a8c4dc7241686c