### PR TITLE
Handle empty target note mapping

### DIFF
--- a/scripts/process.py
+++ b/scripts/process.py
@@ -111,7 +111,11 @@ def load_config() -> dict:
 
 
 def _load_note_mapping() -> dict[str, str]:
-    """Load note replacements from ``configs/local.yml`` if present."""
+    """Load note replacements from ``configs/local.yml`` if present.
+
+    The config may specify an empty ``target`` which indicates that matching
+    ``note`` values should be replaced with an empty string.
+    """
 
     config_path = BASE_DIR / "configs" / "local.yml"
     try:
@@ -124,7 +128,7 @@ def _load_note_mapping() -> dict[str, str]:
     for app in (config.get("apps") or {}).values():
         source = (app.get("source") or "").strip()
         target = app.get("target")
-        if source and target:
+        if source and target is not None:
             mapping[source.lower()] = target
     return mapping
 

--- a/tests/test_note_mapping.py
+++ b/tests/test_note_mapping.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import importlib
+import sys
+import types
+
+
+def test_normalize_note_handles_empty_and_nonempty_target():
+    base_dir = Path(__file__).resolve().parent.parent
+    config_file = base_dir / "configs" / "local.yml"
+    config_file.write_text(
+        """apps:
+  empty_app:
+    source: "XY"
+    target: ""
+  value_app:
+    source: "AB"
+    target: "NewValue"
+""",
+        encoding="utf-8",
+    )
+
+    try:
+        sys.modules.pop("scripts.process", None)
+        sys.modules.setdefault("pandas", types.ModuleType("pandas"))
+        dummy_yaml = types.ModuleType("yaml")
+        dummy_yaml.safe_load = lambda stream: {
+            "apps": {
+                "empty_app": {"source": "XY", "target": ""},
+                "value_app": {"source": "AB", "target": "NewValue"},
+            }
+        }
+        sys.modules.setdefault("yaml", dummy_yaml)
+        process = importlib.import_module("scripts.process")
+        assert process.normalize_note("XY") == ""
+        assert process.normalize_note("xy") == ""
+        assert process.normalize_note("AB") == "NewValue"
+        assert process.normalize_note("ab") == "NewValue"
+        assert process.normalize_note("other") == "other"
+    finally:
+        config_file.unlink()
+        sys.modules.pop("scripts.process", None)
+        sys.modules.pop("pandas", None)
+        sys.modules.pop("yaml", None)
+


### PR DESCRIPTION
## Summary
- handle empty `target` values in `configs/local.yml` and map notes accordingly
- add regression tests for note replacements with empty and non-empty targets

## Testing
- `python -m pytest -q`
- `pip install pandas -q` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e0398c008331b07cfab5f4e6f072