### PR TITLE
Extend report1 generation to include pending devices

### DIFF
--- a/scripts/generate_report1.py
+++ b/scripts/generate_report1.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Generate report1.csv from verified.csv using device mappings."""
+"""Generate report1.csv from verified and pending CSV files using device mappings."""
 from __future__ import annotations
 
 import csv
+from datetime import datetime
 from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -33,9 +34,11 @@ def load_device_mapping() -> list[tuple[str, str]]:
     return devices
 
 
-def read_verified_rows(path: Path) -> list[dict[str, str]]:
-    """Read verified.csv ensuring all fields are strings."""
+def read_rows(path: Path) -> list[dict[str, str]]:
+    """Read CSV ensuring all fields are strings."""
     rows: list[dict[str, str]] = []
+    if not path.exists():
+        return rows
     with open(path, newline="", encoding="utf-8") as fh:
         reader = csv.DictReader(fh)
         for row in reader:
@@ -43,8 +46,10 @@ def read_verified_rows(path: Path) -> list[dict[str, str]]:
     return rows
 
 
-def build_report_rows(devices: list[tuple[str, str]], rows: list[dict[str, str]]) -> list[dict[str, str]]:
-    """Create report rows ordered by device keys."""
+def build_verified_rows(
+    devices: list[tuple[str, str]], rows: list[dict[str, str]]
+) -> list[dict[str, str]]:
+    """Create report rows for verified devices ordered by device keys."""
     report_rows: list[dict[str, str]] = []
     for key, display_name in devices:
         for row in rows:
@@ -76,6 +81,56 @@ def build_report_rows(devices: list[tuple[str, str]], rows: list[dict[str, str]]
     return report_rows
 
 
+def _format_dt(value: str) -> str:
+    """Return ``value`` formatted as ``dd.MM.yyyy HH.mm`` if possible."""
+    if not value:
+        return ""
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        return value
+    return dt.strftime("%d.%m.%Y %H.%M")
+
+
+def build_pending_rows(
+    devices: list[tuple[str, str]], rows: list[dict[str, str]]
+) -> list[dict[str, str]]:
+    """Create report rows for pending devices ordered by device keys."""
+    report_rows: list[dict[str, str]] = []
+    for key, display_name in devices:
+        for row in rows:
+            if row.get("type") != key:
+                continue
+            name = f"{display_name}\n{row.get('name', '')}"
+            ipmac = f"{row.get('ip', '')}\n{row.get('mac', '')}"
+            note_parts = ["Не надано для перевірки."]
+            first = row.get("firstDate", "")
+            last = row.get("lastDate", "")
+            if first and last:
+                first_fmt = _format_dt(first)
+                last_fmt = _format_dt(last)
+                if first == last:
+                    note_parts.append(
+                        f"Перше та останнє підключення – {last_fmt}."
+                    )
+                else:
+                    note_parts.append(
+                        f"Перше підключення – {first_fmt}, останнє підключення – {last_fmt}."
+                    )
+            note = "\n".join(note_parts)
+            report_rows.append(
+                {
+                    "source": row.get("source", ""),
+                    "verified": "false",
+                    "type": row.get("type", ""),
+                    "name": name,
+                    "ipmac": ipmac,
+                    "note": note,
+                }
+            )
+    return report_rows
+
+
 def write_report(rows: list[dict[str, str]], path: Path) -> None:
     """Write rows to CSV at *path* with required columns."""
     fieldnames = ["source", "verified", "type", "name", "ipmac", "note"]
@@ -89,8 +144,13 @@ def write_report(rows: list[dict[str, str]], path: Path) -> None:
 def main() -> None:
     devices = load_device_mapping()
     verified_path = BASE_DIR / "data" / "interim" / "verified.csv"
-    rows = read_verified_rows(verified_path)
-    report_rows = build_report_rows(devices, rows)
+    pending_path = BASE_DIR / "data" / "interim" / "pending.csv"
+
+    verified_rows = read_rows(verified_path)
+    pending_rows = read_rows(pending_path)
+
+    report_rows = build_verified_rows(devices, verified_rows)
+    report_rows.extend(build_pending_rows(devices, pending_rows))
     report_path = BASE_DIR / "data" / "interim" / "report1.csv"
     write_report(report_rows, report_path)
     print(f"Створено файл {report_path}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+# Ensure project root is on the import path so ``scripts`` modules can be imported.
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+

--- a/tests/test_generate_report1_pending.py
+++ b/tests/test_generate_report1_pending.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import csv
+import importlib
+from pathlib import Path
+
+
+def test_generate_report1_includes_pending(tmp_path, monkeypatch):
+    base_dir = tmp_path
+
+    # Prepare configuration
+    (base_dir / "configs").mkdir()
+    (base_dir / "data" / "interim").mkdir(parents=True)
+    (base_dir / "configs" / "base.yaml").write_text(
+        """devices:
+  router: "Маршрутизатор"
+  arm: "АРМ"
+""",
+        encoding="utf-8",
+    )
+
+    # Verified device row
+    (base_dir / "data" / "interim" / "verified.csv").write_text(
+        "source,type,name,ip,mac,randmac,note\n"
+        "VSrc,router,RName,1.1.1.1,aa,,Extra\n",
+        encoding="utf-8",
+    )
+
+    # Pending device row
+    (base_dir / "data" / "interim" / "pending.csv").write_text(
+        "source,name,ip,mac,randmac,type,firstDate,lastDate\n"
+        "PSrc,PName,2.2.2.2,bb,,arm,2024-01-02 03:04,2024-02-03 04:05\n",
+        encoding="utf-8",
+    )
+
+    gr = importlib.import_module("scripts.generate_report1")
+    monkeypatch.setattr(gr, "BASE_DIR", base_dir)
+    gr.main()
+
+    report_path = base_dir / "data" / "interim" / "report1.csv"
+    with open(report_path, encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+
+    assert len(rows) == 2
+    pending = rows[1]
+    assert pending["verified"] == "false"
+    assert pending["type"] == "arm"
+    assert pending["name"] == "АРМ\nPName"
+    assert pending["ipmac"] == "2.2.2.2\nbb"
+    assert (
+        pending["note"]
+        == "Не надано для перевірки.\nПерше підключення – 02.01.2024 03.04, останнє підключення – 03.02.2024 04.05."
+    )
+


### PR DESCRIPTION
## Summary
- handle both verified and pending devices when generating `report1.csv`
- add connection date formatting and pending-specific notes
- cover new behaviour with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2e785ffb883318ee85e27abe75cad