### PR TITLE
Fix pending.csv name in process script

### DIFF
--- a/scripts/process.py
+++ b/scripts/process.py
@@ -691,7 +691,7 @@ def main() -> None:
     )
     run_arm_check(arm_dir, interim_file, report_file2)
     run_mkp_check(mkp_dir, interim_file, report_file2)
-    pending_file = BASE_DIR / "data/interim/рending.csv"
+    pending_file = BASE_DIR / "data/interim/pending.csv"
     run_pending_check(interim_file, verified_file, pending_file)
 
 


### PR DESCRIPTION
## Summary
- replace Cyrillic `р` in `рending.csv` path with Latin `p`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2fdbe4a088331b00178587bf11279