### PR TITLE
Handle last connection note in report1 and unify datetime format

### DIFF
--- a/scripts/generate_report1.py
+++ b/scripts/generate_report1.py
@@ -82,7 +82,7 @@ def build_verified_rows(
 
 
 def _format_dt(value: str) -> str:
-    """Return ``value`` formatted as ``dd.MM.yyyy HH.mm`` if possible."""
+    """Return ``value`` formatted as ``dd.MM.yyyy HH:mm`` if possible."""
     if not value:
         return ""
     value = value.strip()
@@ -99,7 +99,7 @@ def _format_dt(value: str) -> str:
             dt = datetime.fromisoformat(value)
         except ValueError:
             return value
-    return dt.strftime("%d.%m.%Y %H.%M")
+    return dt.strftime("%d.%m.%Y %H:%M")
 
 
 def build_pending_rows(
@@ -127,6 +127,9 @@ def build_pending_rows(
                     note_parts.append(
                         f"Перше підключення – {first_fmt}, останнє підключення – {last_fmt}."
                     )
+            elif not first and last:
+                last_fmt = _format_dt(last)
+                note_parts.append(f"Останнє підключення – {last_fmt}.")
             note = "\n".join(note_parts)
             report_rows.append(
                 {

--- a/tests/test_generate_report1_pending.py
+++ b/tests/test_generate_report1_pending.py
@@ -49,7 +49,7 @@ def test_generate_report1_includes_pending(tmp_path, monkeypatch):
     assert pending["ipmac"] == "2.2.2.2\nbb"
     assert (
         pending["note"]
-        == "Не надано для перевірки.\nПерше підключення – 02.01.2024 03.04, останнє підключення – 03.02.2024 04.05."
+        == "Не надано для перевірки.\nПерше підключення – 02.01.2024 03:04, останнє підключення – 03.02.2024 04:05."
     )
 
 
@@ -92,6 +92,47 @@ def test_generate_report1_handles_epoch_times(tmp_path, monkeypatch):
     pending = rows[1]
     assert pending["note"] == (
         "Не надано для перевірки.\n"
-        "Перше підключення – 02.01.2024 03.04, останнє підключення – 03.02.2024 04.05."
+        "Перше підключення – 02.01.2024 03:04, останнє підключення – 03.02.2024 04:05."
+    )
+
+
+def test_generate_report1_handles_last_date_only(tmp_path, monkeypatch):
+    base_dir = tmp_path
+
+    (base_dir / "configs").mkdir()
+    (base_dir / "data" / "interim").mkdir(parents=True)
+    (base_dir / "configs" / "base.yaml").write_text(
+        """devices:
+  router: \"Маршрутизатор\"
+  arm: \"АРМ\"
+""",
+        encoding="utf-8",
+    )
+
+    (base_dir / "data" / "interim" / "verified.csv").write_text(
+        "source,type,name,ip,mac,randmac,note\n"
+        "VSrc,router,RName,1.1.1.1,aa,,Extra\n",
+        encoding="utf-8",
+    )
+
+    (base_dir / "data" / "interim" / "pending.csv").write_text(
+        "source,name,ip,mac,randmac,type,firstDate,lastDate\n"
+        "PSrc,PName,2.2.2.2,bb,,arm,,2024-02-03 04:05\n",
+        encoding="utf-8",
+    )
+
+    gr = importlib.import_module("scripts.generate_report1")
+    monkeypatch.setattr(gr, "BASE_DIR", base_dir)
+    gr.main()
+
+    report_path = base_dir / "data" / "interim" / "report1.csv"
+    with open(report_path, encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+
+    assert len(rows) == 2
+    pending = rows[1]
+    assert (
+        pending["note"]
+        == "Не надано для перевірки.\nОстаннє підключення – 03.02.2024 04:05."
     )
 


### PR DESCRIPTION
## Summary
- append last connection details to notes when only `lastDate` is provided
- use `dd.MM.yyyy HH:mm` datetime format across report generation
- cover note formatting edge case with new tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a31bb7e7ec8331a0166d95e1649dec