### PR TITLE
Expand verified processing with other device MAC matches

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -11,6 +11,8 @@ paths:
   raw_arm: data/raw/arm
   # Directory with MKP inventory CSV files
   raw_mkp: data/raw/mkp
+  # Directory with additional device CSV files
+  raw_other: data/raw/other
   # Report produced from ARM and MKP checks
   arm_mkp_report: data/result/120report2.csv
 

--- a/scripts/process.py
+++ b/scripts/process.py
@@ -34,6 +34,7 @@ from app.collectors.files import (
     write_csv,
 )
 from app.processors.normalize import normalize_dhcp_records
+from app.processors.verified import append_other_to_verified
 
 
 def load_schemas() -> dict:
@@ -791,9 +792,11 @@ def main() -> None:
 
     arm_dir = BASE_DIR / paths.get("raw_arm", "data/raw/arm")
     mkp_dir = BASE_DIR / paths.get("raw_mkp", "data/raw/mkp")
+    other_dir = BASE_DIR / paths.get("raw_other", "data/raw/other")
     verified_file = BASE_DIR / "data/interim/verified.csv"
     run_arm_interim(arm_dir, interim_file, verified_file)
     run_mkp_interim(mkp_dir, interim_file, verified_file)
+    append_other_to_verified(other_dir, interim_file, verified_file)
     report_file2 = BASE_DIR / paths.get(
         "arm_mkp_report", "data/result/120report2.csv"
     )

--- a/src/app/processors/verified.py
+++ b/src/app/processors/verified.py
@@ -1,0 +1,142 @@
+"""Utilities for working with verified device records."""
+from __future__ import annotations
+
+from pathlib import Path
+import csv
+import re
+from typing import Dict, List
+
+from app.collectors.files import list_csv_files, write_csv
+
+
+def _normalize_mac(value: str) -> str:
+    """Return *value* normalised for comparison.
+
+    The result uses upper-case letters and ``:`` separators with any
+    whitespace removed. Non-hex characters are stripped.
+    """
+
+    hex_only = re.sub(r"[^0-9A-Fa-f]", "", value or "").upper()
+    if len(hex_only) != 12:
+        return ""
+    return ":".join(hex_only[i : i + 2] for i in range(0, 12, 2))
+
+
+def append_other_to_verified(
+    other_dir: Path, dhcp_file: Path, verified_file: Path
+) -> None:
+    """Append devices from ``other_dir`` matched with DHCP data.
+
+    Rows from ``other_dir`` are matched to ``dhcp_file`` by MAC address.
+    New rows are appended to ``verified_file`` while avoiding duplicates.
+    """
+
+    other_dir = Path(other_dir)
+    dhcp_file = Path(dhcp_file)
+    verified_file = Path(verified_file)
+
+    other_files = list_csv_files(other_dir)
+    if not other_files:
+        print(f"Відсутні файли у {other_dir}. Крок додавання other пропущено.")
+        return
+    if not dhcp_file.exists():
+        print(f"Файл {dhcp_file} не знайдено. Крок додавання other пропущено.")
+        return
+
+    # Build MAC index from DHCP file
+    dhcp_index: Dict[str, Dict[str, str]] = {}
+    try:
+        with open(dhcp_file, newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                mac = _normalize_mac(row.get("mac", ""))
+                if mac:
+                    dhcp_index[mac] = row
+    except csv.Error as exc:  # pragma: no cover - unlikely
+        print(f"Помилка читання {dhcp_file}: {exc}")
+        return
+
+    # Load existing entries from verified file
+    existing_keys: set[tuple[str, str, str, str]] = set()
+    if verified_file.exists():
+        try:
+            with open(verified_file, newline="", encoding="utf-8") as fh:
+                reader = csv.DictReader(fh)
+                for row in reader:
+                    key = (
+                        row.get("type", ""),
+                        row.get("source", ""),
+                        row.get("ip", ""),
+                        _normalize_mac(row.get("mac", "")),
+                    )
+                    existing_keys.add(key)
+        except csv.Error as exc:  # pragma: no cover - unlikely
+            print(f"Помилка читання {verified_file}: {exc}")
+            return
+
+    fieldnames = [
+        "type",
+        "source",
+        "name",
+        "ip",
+        "mac",
+        "randmac",
+        "owner",
+        "note",
+        "firstDate",
+        "lastDate",
+    ]
+
+    new_rows: List[Dict[str, str]] = []
+    match_count = 0
+    dup_count = 0
+
+    for path in other_files:
+        try:
+            with open(path, newline="", encoding="utf-8") as fh:
+                reader = csv.DictReader(fh)
+                for row in reader:
+                    mac = _normalize_mac(row.get("mac", ""))
+                    if not mac:
+                        continue
+                    dhcp_row = dhcp_index.get(mac)
+                    if not dhcp_row:
+                        continue
+                    match_count += 1
+                    out_row = {
+                        "type": row.get("type", ""),
+                        "source": dhcp_row.get("source", ""),
+                        "name": row.get("name", ""),
+                        "ip": dhcp_row.get("ip", ""),
+                        "mac": dhcp_row.get("mac", ""),
+                        "randmac": "",
+                        "owner": "",
+                        "note": "",
+                        "firstDate": dhcp_row.get("firstDate", ""),
+                        "lastDate": dhcp_row.get("lastDate", ""),
+                    }
+                    key = (
+                        out_row["type"],
+                        out_row["source"],
+                        out_row["ip"],
+                        mac,
+                    )
+                    if key in existing_keys:
+                        dup_count += 1
+                        continue
+                    existing_keys.add(key)
+                    new_rows.append(out_row)
+        except csv.Error as exc:
+            print(f"Некоректний CSV у {path}: {exc}")
+
+    if new_rows:
+        file_created = write_csv(verified_file, fieldnames, new_rows, append=True)
+        action = "Створено" if file_created else "Оновлено"
+        print(f"{action} файл {verified_file}")
+        print(f"Додано {len(new_rows)} нових рядків.")
+    else:
+        print(f"Нових записів не додано до {verified_file}.")
+
+    print(f"Опрацьовано {len(other_files)} файлів.")
+    print(f"Знайдено {match_count} збігів по MAC.")
+    print(f"Пропущено {dup_count} рядків через дублювання.")

--- a/tests/test_append_other_to_verified.py
+++ b/tests/test_append_other_to_verified.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+import csv
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from app.processors.verified import append_other_to_verified
+
+
+def read_rows(path: Path):
+    with open(path, newline="", encoding="utf-8") as fh:
+        return list(csv.DictReader(fh))
+
+
+def test_append_and_idempotent(tmp_path: Path) -> None:
+    other_dir = tmp_path / "data/raw/other"
+    dhcp_file = tmp_path / "data/interim/dhcp.csv"
+    verified_file = tmp_path / "data/interim/verified.csv"
+    other_dir.mkdir(parents=True)
+    dhcp_file.parent.mkdir(parents=True)
+    verified_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # other csv with MAC containing spaces to test normalization
+    (other_dir / "devices.csv").write_text(
+        "type,name,ip,mac,note\nrouter,dev1,,aa bb cc dd ee ff,\n",
+        encoding="utf-8",
+    )
+
+    dhcp_file.write_text(
+        "source,ip,mac,firstDate,lastDate\n"
+        "s1,10.0.0.1,AA:BB:CC:DD:EE:FF,1,2\n",
+        encoding="utf-8",
+    )
+
+    append_other_to_verified(other_dir, dhcp_file, verified_file)
+    rows = read_rows(verified_file)
+    assert len(rows) == 1
+    assert rows[0]["mac"] == "AA:BB:CC:DD:EE:FF"
+    assert rows[0]["type"] == "router"
+    assert rows[0]["source"] == "s1"
+
+    # Second run should not duplicate
+    append_other_to_verified(other_dir, dhcp_file, verified_file)
+    rows = read_rows(verified_file)
+    assert len(rows) == 1
+
+
+def test_missing_inputs(tmp_path: Path) -> None:
+    other_dir = tmp_path / "data/raw/other"
+    dhcp_file = tmp_path / "data/interim/dhcp.csv"
+    verified_file = tmp_path / "data/interim/verified.csv"
+
+    # Do not create required files/directories
+    append_other_to_verified(other_dir, dhcp_file, verified_file)
+    assert not verified_file.exists()


### PR DESCRIPTION
## Summary
- append devices from `data/raw/other` to `data/interim/verified.csv` when their MAC is present in DHCP records, avoiding duplicates
- wire new `append_other_to_verified` step into processing pipeline and configuration
- add regression tests for MAC matching and missing input handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a41dd46de48331bdea46f42309d233