### PR TITLE
feat(verified): add Random/Dynamic MAC matching

### DIFF
--- a/configs/schemas.yml
+++ b/configs/schemas.yml
@@ -5,6 +5,7 @@ arm:
   owner: "Власник"
   pc_type: "Тип ПК"
   ip: "IP"
+  randmac: "Random MAC"
 mkp:
   mac: "Статичний MAC"
   model: "Модель"

--- a/scripts/process.py
+++ b/scripts/process.py
@@ -362,36 +362,65 @@ def run_arm_interim(arm_dir: Path, dhcp_file: Path, verified_file: Path) -> None
                 existing_macs.add(mac)
 
     rows_to_write = []
+    file_count = 0
+    rand_matches = 0
+    invalid_rand = 0
 
     if arm_dir.exists():
         for path in list_csv_files(arm_dir):
+            file_count += 1
             for row in read_csv_mapped(
-                path, "arm", ["mac", "hostname", "owner", "pc_type"]
+                path, "arm", ["mac", "hostname", "owner", "pc_type", "randmac"]
             ):
                 mac_raw = (row.get("mac", "") or "").strip()
-                if not MAC_RE.fullmatch(mac_raw):
-                    continue
-                mac = mac_raw.upper().replace("-", ":")
-                if mac in existing_macs:
-                    continue
-                dhcp_row = dhcp_records.get(mac)
-                if not dhcp_row:
-                    continue
-                rows_to_write.append(
-                    {
-                        "type": "arm",
-                        "source": dhcp_row.get("source", ""),
-                        "name": row.get("hostname", ""),
-                        "ip": dhcp_row.get("ip", ""),
-                        "mac": mac,
-                        "randmac": "",
-                        "owner": row.get("owner", ""),
-                        "note": normalize_note(row.get("pc_type", "")),
-                        "firstDate": dhcp_row.get("firstDate", ""),
-                        "lastDate": dhcp_row.get("lastDate", ""),
-                    }
-                )
-                existing_macs.add(mac)
+                if MAC_RE.fullmatch(mac_raw):
+                    mac = mac_raw.upper().replace("-", ":")
+                else:
+                    mac = ""
+                rand_raw = (row.get("randmac", "") or "").strip()
+                rand_norm = _normalize_mac(rand_raw)
+                if rand_raw and not MAC_RE.fullmatch(rand_norm):
+                    invalid_rand += 1
+                    rand_norm = ""
+
+                if mac and mac not in existing_macs:
+                    dhcp_row = dhcp_records.get(mac)
+                    if dhcp_row:
+                        rows_to_write.append(
+                            {
+                                "type": "arm",
+                                "source": dhcp_row.get("source", ""),
+                                "name": row.get("hostname", ""),
+                                "ip": dhcp_row.get("ip", ""),
+                                "mac": mac,
+                                "randmac": "",
+                                "owner": row.get("owner", ""),
+                                "note": normalize_note(row.get("pc_type", "")),
+                                "firstDate": dhcp_row.get("firstDate", ""),
+                                "lastDate": dhcp_row.get("lastDate", ""),
+                            }
+                        )
+                        existing_macs.add(mac)
+
+                if rand_norm and rand_norm not in existing_macs:
+                    dhcp_row = dhcp_records.get(rand_norm)
+                    if dhcp_row:
+                        rows_to_write.append(
+                            {
+                                "type": "rarm",
+                                "source": dhcp_row.get("source", ""),
+                                "name": row.get("hostname", ""),
+                                "ip": dhcp_row.get("ip", ""),
+                                "mac": rand_norm,
+                                "randmac": mac,
+                                "owner": row.get("owner", ""),
+                                "note": normalize_note(row.get("pc_type", "")),
+                                "firstDate": dhcp_row.get("firstDate", ""),
+                                "lastDate": dhcp_row.get("lastDate", ""),
+                            }
+                        )
+                        existing_macs.add(rand_norm)
+                        rand_matches += 1
     else:
         print(f"Відсутні файли для перевірки у {arm_dir}. Крок ARM interim пропущено.")
 
@@ -415,6 +444,9 @@ def run_arm_interim(arm_dir: Path, dhcp_file: Path, verified_file: Path) -> None
     action = "Створено" if file_created else "Оновлено"
     print(f"{action} файл {verified_file}")
     print(f"Додано {len(rows_to_write)} нових записів.")
+    print(f"Опрацьовано {file_count} файлів.")
+    print(f"Знайдено {rand_matches} збігів по Random MAC.")
+    print(f"Пропущено {invalid_rand} рядків через невалідні Random MAC.")
 
 
 def run_mkp_interim(mkp_dir: Path, dhcp_file: Path, verified_file: Path) -> None:
@@ -454,43 +486,66 @@ def run_mkp_interim(mkp_dir: Path, dhcp_file: Path, verified_file: Path) -> None
                 existing_macs.add(mac)
 
     rows_to_write = []
+    file_count = 0
+    rand_matches = 0
+    invalid_rand = 0
 
     if mkp_dir.exists():
         for path in list_csv_files(mkp_dir):
+            file_count += 1
             for row in read_csv_mapped(
                 path,
                 "mkp",
                 ["mac", "model", "owner", "mkp_type", "randmac"],
             ):
                 mac_raw = (row.get("mac", "") or "").strip()
-                if not MAC_RE.fullmatch(mac_raw):
-                    continue
-                mac = mac_raw.upper().replace("-", ":")
-                if mac in existing_macs:
-                    continue
-                dhcp_row = dhcp_records.get(mac)
-                if not dhcp_row:
-                    continue
-                randmac_raw = (row.get("randmac", "") or "").strip()
-                if MAC_RE.fullmatch(randmac_raw):
-                    randmac = randmac_raw.upper().replace("-", ":")
-                else:
-                    randmac = ""
-                rows_to_write.append(
-                    {
-                        "type": "mkp",
-                        "source": dhcp_row.get("source", ""),
-                        "name": row.get("model", ""),
-                        "ip": dhcp_row.get("ip", ""),
-                        "mac": mac,
-                        "randmac": randmac,
-                        "owner": row.get("owner", ""),
-                        "note": normalize_note(row.get("mkp_type", "")),
-                        "firstDate": dhcp_row.get("firstDate", ""),
-                        "lastDate": dhcp_row.get("lastDate", ""),
-                    }
-                )
-                existing_macs.add(mac)
+                mac_norm = _normalize_mac(mac_raw)
+                if mac_raw and not MAC_RE.fullmatch(mac_norm):
+                    mac_norm = ""
+                rand_raw = (row.get("randmac", "") or "").strip()
+                rand_norm = _normalize_mac(rand_raw)
+                if rand_raw and not MAC_RE.fullmatch(rand_norm):
+                    invalid_rand += 1
+                    rand_norm = ""
+
+                if mac_norm and mac_norm not in existing_macs:
+                    dhcp_row = dhcp_records.get(mac_norm)
+                    if dhcp_row:
+                        rows_to_write.append(
+                            {
+                                "type": "mkp",
+                                "source": dhcp_row.get("source", ""),
+                                "name": row.get("model", ""),
+                                "ip": dhcp_row.get("ip", ""),
+                                "mac": mac_norm,
+                                "randmac": rand_norm,
+                                "owner": row.get("owner", ""),
+                                "note": normalize_note(row.get("mkp_type", "")),
+                                "firstDate": dhcp_row.get("firstDate", ""),
+                                "lastDate": dhcp_row.get("lastDate", ""),
+                            }
+                        )
+                        existing_macs.add(mac_norm)
+
+                if rand_norm and rand_norm not in existing_macs:
+                    dhcp_row = dhcp_records.get(rand_norm)
+                    if dhcp_row:
+                        rows_to_write.append(
+                            {
+                                "type": "rmkp",
+                                "source": dhcp_row.get("source", ""),
+                                "name": row.get("model", ""),
+                                "ip": dhcp_row.get("ip", ""),
+                                "mac": rand_norm,
+                                "randmac": mac_norm,
+                                "owner": row.get("owner", ""),
+                                "note": normalize_note(row.get("mkp_type", "")),
+                                "firstDate": dhcp_row.get("firstDate", ""),
+                                "lastDate": dhcp_row.get("lastDate", ""),
+                            }
+                        )
+                        existing_macs.add(rand_norm)
+                        rand_matches += 1
     else:
         print(f"Відсутні файли для перевірки у {mkp_dir}. Крок МКП interim пропущено.")
 
@@ -514,6 +569,9 @@ def run_mkp_interim(mkp_dir: Path, dhcp_file: Path, verified_file: Path) -> None
     action = "Створено" if file_created else "Оновлено"
     print(f"{action} файл {verified_file}")
     print(f"Додано {len(rows_to_write)} нових записів.")
+    print(f"Опрацьовано {file_count} файлів.")
+    print(f"Знайдено {rand_matches} збігів по Random MAC.")
+    print(f"Пропущено {invalid_rand} рядків через невалідні Random MAC.")
 
 def run_arm_check(arm_dir: Path, dhcp_file: Path, report_file: Path) -> None:
     """Generate ARM report from *arm_dir* against *dhcp_file*.

--- a/tests/test_random_dynamic_verified.py
+++ b/tests/test_random_dynamic_verified.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+import csv
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from scripts.process import run_arm_interim, run_mkp_interim
+
+
+def read_rows(path: Path):
+    with open(path, newline="", encoding="utf-8") as fh:
+        return list(csv.DictReader(fh))
+
+
+def test_rarm_and_idempotent(tmp_path: Path) -> None:
+    arm_dir = tmp_path / "data/raw/arm"
+    dhcp_file = tmp_path / "data/interim/dhcp.csv"
+    verified_file = tmp_path / "data/interim/verified.csv"
+    arm_dir.mkdir(parents=True)
+    dhcp_file.parent.mkdir(parents=True)
+    verified_file.parent.mkdir(parents=True, exist_ok=True)
+
+    (arm_dir / "arm.csv").write_text(
+        "Static MAC,Hostname,Власник,Тип ПК,Random MAC\n"
+        "AA-BB-CC-DD-EE-FF,host1,,pc,b1-67-2d-f4-ca-49\n",
+        encoding="utf-8",
+    )
+
+    dhcp_file.write_text(
+        "source,ip,mac,firstDate,lastDate\n"
+        "s1,10.0.0.1,B1:67:2D:F4:CA:49,1,2\n",
+        encoding="utf-8",
+    )
+
+    run_arm_interim(arm_dir, dhcp_file, verified_file)
+    rows = read_rows(verified_file)
+    assert len(rows) == 1
+    assert rows[0]["type"] == "rarm"
+    assert rows[0]["mac"] == "B1:67:2D:F4:CA:49"
+    assert rows[0]["randmac"] == "AA:BB:CC:DD:EE:FF"
+
+    # Idempotent on second run
+    run_arm_interim(arm_dir, dhcp_file, verified_file)
+    rows2 = read_rows(verified_file)
+    assert rows2 == rows
+
+
+def test_rmkp_and_idempotent(tmp_path: Path) -> None:
+    mkp_dir = tmp_path / "data/raw/mkp"
+    dhcp_file = tmp_path / "data/interim/dhcp.csv"
+    verified_file = tmp_path / "data/interim/verified.csv"
+    mkp_dir.mkdir(parents=True)
+    dhcp_file.parent.mkdir(parents=True)
+    verified_file.parent.mkdir(parents=True, exist_ok=True)
+
+    (mkp_dir / "mkp.csv").write_text(
+        "Статичний MAC,Модель,Відповідальний,Тип МКП,Динамічний MAC\n"
+        "AA-BB-CC-DD-EE-01,model1,owner1,,de.e4.16.ac.71.fe\n",
+        encoding="utf-8",
+    )
+
+    dhcp_file.write_text(
+        "source,ip,mac,firstDate,lastDate\n"
+        "s1,10.0.0.2,DE:E4:16:AC:71:FE,3,4\n",
+        encoding="utf-8",
+    )
+
+    run_mkp_interim(mkp_dir, dhcp_file, verified_file)
+    rows = read_rows(verified_file)
+    assert len(rows) == 1
+    assert rows[0]["type"] == "rmkp"
+    assert rows[0]["mac"] == "DE:E4:16:AC:71:FE"
+    assert rows[0]["randmac"] == "AA:BB:CC:DD:EE:01"
+
+    run_mkp_interim(mkp_dir, dhcp_file, verified_file)
+    rows2 = read_rows(verified_file)
+    assert rows2 == rows
+


### PR DESCRIPTION
## Summary
- support Random/Dynamic MAC mapping for ARM and MKP
- extend ARM/MKP interim processing to match DHCP using random MACs and record rarm/rmkp types with deduplication
- test random/dynamic MAC handling and idempotency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6d97794e483319a88bd73687aa30e