### PR TITLE
feat: add clean option to process script

### DIFF
--- a/scripts/process.py
+++ b/scripts/process.py
@@ -864,7 +864,31 @@ def run_pending_check(
     print(f"Додано {len(rows_to_write)} нових записів.")
 
 
-def main() -> None:
+def clean_interim(directory: Path | None = None) -> None:
+    """Delete interim CSV files except examples.
+
+    Files ending with ``.example.csv`` are preserved. Missing directories or
+    files are ignored.
+    """
+
+    directory = Path(directory or BASE_DIR / "data/interim")
+    for path in directory.glob("*.csv"):
+        if path.name.endswith(".example.csv"):
+            print(f"[INFO] Залишено: {path.name}")
+            continue
+        try:
+            path.unlink()
+            print(f"[INFO] Видалено: {path.name}")
+        except FileNotFoundError:  # pragma: no cover - already deleted
+            pass
+
+
+def main(argv: list[str] | None = None) -> None:
+    argv = list(argv or sys.argv[1:])
+    if argv and argv[0] == "clean":
+        clean_interim()
+        argv = argv[1:]
+
     config = load_config()
     paths = config.get("paths", {})
 

--- a/tests/test_clean_option.py
+++ b/tests/test_clean_option.py
@@ -1,0 +1,22 @@
+import os
+from pathlib import Path
+
+from scripts import process
+
+
+def test_clean_interim(tmp_path):
+    interim = tmp_path / "interim"
+    interim.mkdir()
+    to_remove = interim / "remove.csv"
+    to_remove.write_text("data")
+    to_keep = interim / "keep.example.csv"
+    to_keep.write_text("data")
+
+    process.clean_interim(interim)
+
+    assert not to_remove.exists()
+    assert to_keep.exists()
+
+    # Should not raise when nothing to remove
+    process.clean_interim(interim)
+    assert to_keep.exists()


### PR DESCRIPTION
## Summary
- add clean_interim helper and optional `clean` CLI argument to remove interim CSVs before processing
- cover interim cleaning behaviour with unit test

## Testing
- `pytest -q`
- `python scripts/process.py clean`

------
https://chatgpt.com/codex/tasks/task_e_68a6f654ef6c83319dbf3f958f723622