### PR TITLE
Add script for matching pending MAC addresses

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts for Harvester Prime."""

--- a/scripts/mac_pending.py
+++ b/scripts/mac_pending.py
@@ -1,0 +1,116 @@
+"""Check pending MACs against raw MKP CSV files.
+
+This script reads ``data/interim/pending.csv`` and scans all CSV files in
+``data/raw/mkp`` for partial MAC address matches (at least four consecutive
+blocks). For each match, the corresponding rows from both sources are appended
+to ``data/interim/mac-pending.csv``.
+"""
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pandas as pd
+
+
+def _mac_blocks(mac: str) -> list[str]:
+    """Return colon-separated MAC address blocks in upper case."""
+    return [block.upper() for block in mac.split(":") if block]
+
+
+def _max_consecutive_blocks(mac1: str, mac2: str) -> int:
+    """Return length of the longest common block sequence between two MACs."""
+    blocks1 = _mac_blocks(mac1)
+    blocks2 = _mac_blocks(mac2)
+    max_match = 0
+    for i in range(len(blocks1)):
+        for j in range(len(blocks2)):
+            k = 0
+            while (
+                i + k < len(blocks1)
+                and j + k < len(blocks2)
+                and blocks1[i + k] == blocks2[j + k]
+            ):
+                k += 1
+            if k > max_match:
+                max_match = k
+    return max_match
+
+
+def find_partial_mac_matches(
+    pending_path: Path,
+    raw_dir: Path,
+    output_path: Path,
+    *,
+    min_blocks: int = 4,
+) -> int:
+    """Append matching rows to *output_path* and return number of matches.
+
+    Parameters
+    ----------
+    pending_path:
+        Path to ``pending.csv`` containing a ``mac`` column.
+    raw_dir:
+        Directory containing raw ``mkp`` CSV files.
+    output_path:
+        File where matches should be appended. Created if missing.
+    min_blocks:
+        Minimum number of consecutive matching blocks required (default 4).
+    """
+
+    if not pending_path.exists():
+        return 0
+
+    pending_df = pd.read_csv(pending_path, dtype=str).fillna("")
+    pending_rows = pending_df.to_dict("records")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = ["source", "file", "mac", "row"]
+    file_exists = output_path.exists()
+    written = 0
+
+    with open(output_path, "a", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        if not file_exists:
+            writer.writeheader()
+
+        for raw_file in sorted(raw_dir.glob("*.csv")):
+            df = pd.read_csv(raw_file, dtype=str).fillna("")
+            for _, row in df.iterrows():
+                for col in ("Статичний MAC", "Динамічний MAC"):
+                    mac_raw = row.get(col, "")
+                    if not mac_raw:
+                        continue
+                    for pending_row in pending_rows:
+                        mac_pending = pending_row.get("mac", "")
+                        if mac_pending and _max_consecutive_blocks(mac_pending, mac_raw) >= min_blocks:
+                            writer.writerow(
+                                {
+                                    "source": "pending",
+                                    "file": str(pending_path),
+                                    "mac": mac_pending,
+                                    "row": pending_row,
+                                }
+                            )
+                            writer.writerow(
+                                {
+                                    "source": "raw",
+                                    "file": str(raw_file),
+                                    "mac": mac_raw,
+                                    "row": row.to_dict(),
+                                }
+                            )
+                            written += 1
+    return written
+
+
+def main() -> None:
+    base = Path(__file__).resolve().parents[1]
+    pending_path = base / "data" / "interim" / "pending.csv"
+    raw_dir = base / "data" / "raw" / "mkp"
+    output_path = base / "data" / "interim" / "mac-pending.csv"
+    find_partial_mac_matches(pending_path, raw_dir, output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mac_pending.py
+++ b/tests/test_mac_pending.py
@@ -1,0 +1,39 @@
+import csv
+from pathlib import Path
+
+from scripts.mac_pending import find_partial_mac_matches
+
+
+def test_find_partial_mac_matches(tmp_path: Path) -> None:
+    pending_dir = tmp_path / "data" / "interim"
+    raw_dir = tmp_path / "data" / "raw" / "mkp"
+    pending_dir.mkdir(parents=True)
+    raw_dir.mkdir(parents=True)
+
+    pending_file = pending_dir / "pending.csv"
+    pending_file.write_text("mac\nC2:3A:4B:5C:6D:7E\n", encoding="utf-8")
+
+    raw_file = raw_dir / "sample.csv"
+    raw_file.write_text(
+        "Статичний MAC,Динамічний MAC\n" "2C:3A:4B:5C:6D:7E,AA:BB:CC:DD:EE:FF\n",
+        encoding="utf-8",
+    )
+
+    output_file = pending_dir / "mac-pending.csv"
+    count = find_partial_mac_matches(pending_file, raw_dir, output_file)
+    assert count == 1
+
+    with open(output_file, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+    assert len(rows) == 2
+    assert rows[0]["source"] == "pending"
+    assert rows[0]["mac"] == "C2:3A:4B:5C:6D:7E"
+    assert rows[1]["source"] == "raw"
+    assert rows[1]["mac"] == "2C:3A:4B:5C:6D:7E"
+
+    # Calling again should append to the existing file
+    count = find_partial_mac_matches(pending_file, raw_dir, output_file)
+    assert count == 1
+    with open(output_file, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+    assert len(rows) == 4


### PR DESCRIPTION
## Summary
- add script to scan MKP CSVs for MAC addresses partially matching pending entries
- append matching rows to `data/interim/mac-pending.csv` without overwriting
- cover behavior with regression test

## Testing
- `pytest tests/test_mac_pending.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a71114e00c8331bccc383e625502e2