### PR TITLE
Append pc type mappings to note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Added support for appending `Тип ПК` mappings from `configs/local.yml` to the `note` column when generating `data/interim/verified.csv`.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ ignore:
 MAC addresses listed there are excluded from the generated
 `data/interim/dhcp.csv` file.
 
+The same configuration file can include application mappings under the
+`apps` section. Each mapping provides a `source` value to match against the
+`Тип ПК` column of ARM and MKP inventory files and a `target` string to append
+to the resulting `note` in `data/interim/verified.csv`:
+
+```yaml
+apps:
+  office:
+    source: "офіс"
+    target: "Microsoft Office"
+```
+
+With this configuration a workstation with `Тип ПК` set to `офіс` will have
+its note recorded as `Надано на перевірку. Microsoft Office`. If no mapping is
+found the note remains unchanged and a warning is printed during processing.
+
 ## Raw data directories
 
 The script reads several directories under `data/raw`. Each CSV file must

--- a/scripts/process.py
+++ b/scripts/process.py
@@ -142,7 +142,9 @@ def _load_note_mapping() -> dict[str, str]:
         source = (app.get("source") or "").strip()
         target = app.get("target")
         if source and target is not None:
-            mapping[source.lower()] = target
+            # Keys are normalised to be case- and space-insensitive
+            key = source.lower().replace(" ", "")
+            mapping[key] = target
     return mapping
 
 
@@ -180,11 +182,30 @@ def _load_ignore_macs() -> set[str]:
     return macs
 
 
-def normalize_note(note: str) -> str:
-    """Return note value replaced according to NOTE_MAPPING."""
+def append_note_from_pc_type(note: str, pc_type: str) -> str:
+    """Return ``note`` with mapped ``pc_type`` target appended.
 
-    key = (note or "").strip().lower()
-    return NOTE_MAPPING.get(key, note)
+    Mapping values are loaded from :mod:`configs/local.yml`. Comparison is
+    performed ignoring case and whitespace. If ``pc_type`` is not present in
+    the mapping the note is returned unchanged and a warning is printed.
+    """
+
+    key = (pc_type or "").strip().lower().replace(" ", "")
+    target = NOTE_MAPPING.get(key)
+    if target:
+        note = (note or "").strip()
+        if note and not note.endswith("."):
+            note += "."
+        if note:
+            note += f" {target}"
+        else:
+            note = target
+    else:
+        if pc_type:
+            print(
+                f'Попередження: значення "{pc_type}" відсутнє у configs/local.yml'
+            )
+    return note
 
 
 def run_validation(validation_dir: Path, dhcp_file: Path, report_file: Path) -> None:
@@ -443,7 +464,9 @@ def run_arm_interim(arm_dir: Path, dhcp_file: Path, verified_file: Path) -> None
                                 "mac": mac,
                                 "randmac": "",
                                 "owner": row.get("owner", ""),
-                                "note": normalize_note(row.get("pc_type", "")),
+                                "note": append_note_from_pc_type(
+                                    "Надано на перевірку.", row.get("pc_type", "")
+                                ),
                                 "firstDate": dhcp_row.get("firstDate", ""),
                                 "lastDate": dhcp_row.get("lastDate", ""),
                                 "personal": "true" if is_personal else "false",
@@ -463,7 +486,9 @@ def run_arm_interim(arm_dir: Path, dhcp_file: Path, verified_file: Path) -> None
                                 "mac": rand_norm,
                                 "randmac": mac,
                                 "owner": row.get("owner", ""),
-                                "note": normalize_note(row.get("pc_type", "")),
+                                "note": append_note_from_pc_type(
+                                    "Надано на перевірку.", row.get("pc_type", "")
+                                ),
                                 "firstDate": dhcp_row.get("firstDate", ""),
                                 "lastDate": dhcp_row.get("lastDate", ""),
                                 "personal": "true" if is_personal else "false",
@@ -573,7 +598,9 @@ def run_mkp_interim(mkp_dir: Path, dhcp_file: Path, verified_file: Path) -> None
                                 "mac": mac_norm,
                                 "randmac": rand_norm,
                                 "owner": row.get("owner", ""),
-                                "note": normalize_note(row.get("mkp_type", "")),
+                                "note": append_note_from_pc_type(
+                                    "Надано на перевірку.", row.get("mkp_type", "")
+                                ),
                                 "firstDate": dhcp_row.get("firstDate", ""),
                                 "lastDate": dhcp_row.get("lastDate", ""),
                                 "personal": "true" if is_personal else "false",
@@ -593,7 +620,9 @@ def run_mkp_interim(mkp_dir: Path, dhcp_file: Path, verified_file: Path) -> None
                                 "mac": rand_norm,
                                 "randmac": mac_norm,
                                 "owner": row.get("owner", ""),
-                                "note": normalize_note(row.get("mkp_type", "")),
+                                "note": append_note_from_pc_type(
+                                    "Надано на перевірку.", row.get("mkp_type", "")
+                                ),
                                 "firstDate": dhcp_row.get("firstDate", ""),
                                 "lastDate": dhcp_row.get("lastDate", ""),
                                 "personal": "true" if is_personal else "false",

--- a/tests/test_note_mapping.py
+++ b/tests/test_note_mapping.py
@@ -1,44 +1,74 @@
-from pathlib import Path
-import importlib
+from __future__ import annotations
+
+import csv
 import sys
 import types
+from pathlib import Path
 
 
-def test_normalize_note_handles_empty_and_nonempty_target():
-    base_dir = Path(__file__).resolve().parent.parent
-    config_file = base_dir / "configs" / "local.yml"
-    config_file.write_text(
-        """apps:
-  empty_app:
-    source: "XY"
-    target: ""
-  value_app:
-    source: "AB"
-    target: "NewValue"
-""",
+def read_rows(path: Path):
+    with open(path, newline="", encoding="utf-8") as fh:
+        return list(csv.DictReader(fh))
+
+
+def test_note_mapping_appended(tmp_path, capsys, monkeypatch):
+    base_dir = tmp_path
+    arm_dir = base_dir / "data/raw/arm"
+    dhcp_file = base_dir / "data/interim/dhcp.csv"
+    verified_file = base_dir / "data/interim/verified.csv"
+    arm_dir.mkdir(parents=True)
+    dhcp_file.parent.mkdir(parents=True)
+    verified_file.parent.mkdir(parents=True, exist_ok=True)
+
+    (arm_dir / "arm.csv").write_text(
+        "Static MAC,Hostname,Власник,Тип ПК,Random MAC,Власність\n"
+        "AA-AA-AA-AA-AA-01,pc1,owner1,офіс,,\n"
+        "AA-AA-AA-AA-AA-02,pc2,owner2, х Р О М ,,\n"
+        "AA-AA-AA-AA-AA-03,pc3,owner3,ігровий,,\n",
         encoding="utf-8",
     )
 
-    try:
-        sys.modules.pop("scripts.process", None)
-        sys.modules.setdefault("pandas", types.ModuleType("pandas"))
-        dummy_yaml = types.ModuleType("yaml")
-        dummy_yaml.safe_load = lambda stream: {
-            "apps": {
-                "empty_app": {"source": "XY", "target": ""},
-                "value_app": {"source": "AB", "target": "NewValue"},
-            }
-        }
-        sys.modules.setdefault("yaml", dummy_yaml)
-        process = importlib.import_module("scripts.process")
-        assert process.normalize_note("XY") == ""
-        assert process.normalize_note("xy") == ""
-        assert process.normalize_note("AB") == "NewValue"
-        assert process.normalize_note("ab") == "NewValue"
-        assert process.normalize_note("other") == "other"
-    finally:
-        config_file.unlink()
-        sys.modules.pop("scripts.process", None)
-        sys.modules.pop("pandas", None)
-        sys.modules.pop("yaml", None)
+    dhcp_file.write_text(
+        "source,ip,mac,firstDate,lastDate\n"
+        "s1,1.1.1.1,AA:AA:AA:AA:AA:01,1,2\n"
+        "s1,1.1.1.2,AA:AA:AA:AA:AA:02,1,2\n"
+        "s1,1.1.1.3,AA:AA:AA:AA:AA:03,1,2\n",
+        encoding="utf-8",
+    )
 
+    dummy_yaml = types.ModuleType("yaml")
+    dummy_yaml.safe_load = lambda stream: {
+        "arm": {
+            "mac": "Static MAC",
+            "hostname": "Hostname",
+            "owner": "Власник",
+            "pc_type": "Тип ПК",
+            "randmac": "Random MAC",
+            "ownership": "Власність",
+        },
+        "dhcp": {
+            "mac": "mac",
+            "ip": "ip",
+            "source": "source",
+            "firstDate": "firstDate",
+            "lastDate": "lastDate",
+        },
+    }
+    sys.modules["yaml"] = dummy_yaml
+    sys.modules.pop("scripts.process", None)
+    import scripts.process as process
+    monkeypatch.setattr(process, "BASE_DIR", base_dir)
+    process.SCHEMAS = dummy_yaml.safe_load(None)
+    process.NOTE_MAPPING = {
+        "офіс": "Microsoft Office",
+        "хром": "Google Chrome",
+    }
+
+    process.run_arm_interim(arm_dir, dhcp_file, verified_file)
+    rows = read_rows(verified_file)
+    assert rows[0]["note"] == "Надано на перевірку. Microsoft Office"
+    assert rows[1]["note"] == "Надано на перевірку. Google Chrome"
+    assert rows[2]["note"] == "Надано на перевірку."
+
+    captured = capsys.readouterr()
+    assert "ігровий" in captured.out


### PR DESCRIPTION
## Summary
- load application mappings from `configs/local.yml` ignoring case and spaces
- append matched app `target` to verified rows when processing ARM and MKP data
- document mapping behaviour and add changelog entry

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas -q` *(fails: Could not find a version that satisfies the requirement pandas)*
- `pytest tests/test_note_mapping.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9a13fe62083319156678892212531