### PR TITLE
Handle whitespace when parsing CSV files

### DIFF
--- a/src/app/collectors/files.py
+++ b/src/app/collectors/files.py
@@ -38,12 +38,14 @@ def read_csv(path: Path, columns: Optional[Iterable[str]] = DHCP_COLUMNS) -> Lis
     """
     rows: List[Dict[str, str]] = []
     with open(path, newline="", encoding="utf-8") as fh:
-        reader = csv.DictReader(fh)
+        reader = csv.DictReader(fh, skipinitialspace=True)
+        reader.fieldnames = [h.strip() for h in reader.fieldnames or []]
         if columns is None:
-            rows.extend(row for row in reader)
+            for row in reader:
+                rows.append({k: (v or "").strip() for k, v in row.items()})
         else:
             for row in reader:
-                rows.append({col: row.get(col, "") for col in columns})
+                rows.append({col: row.get(col, "").strip() for col in columns})
     return rows
 
 


### PR DESCRIPTION
## Summary
- Trim whitespace from CSV headers
- Strip whitespace from field values and support skipinitialspace in `DictReader`

## Testing
- `python scripts/process.py`
- `python - <<'PY'
from pathlib import Path
import sys
sys.path.append('src')
from app.collectors.files import read_csv
rows = read_csv(Path('data/raw/arm/data.example.csv'), columns=['MAC','Hostname','Власник','Тип ПК','IP'])
print(rows)
PY`
- `pytest` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a9f06b58748331bd3359fac1c98702