### PR TITLE
Handle UTF-8 BOM in CSV reader

### DIFF
--- a/src/app/collectors/files.py
+++ b/src/app/collectors/files.py
@@ -37,7 +37,8 @@ def read_csv(path: Path, columns: Optional[Iterable[str]] = DHCP_COLUMNS) -> Lis
         columns from the file are included.
     """
     rows: List[Dict[str, str]] = []
-    with open(path, newline="", encoding="utf-8") as fh:
+    # ``utf-8-sig`` ensures an optional BOM is stripped automatically
+    with open(path, newline="", encoding="utf-8-sig") as fh:
         reader = csv.DictReader(fh, skipinitialspace=True)
         reader.fieldnames = [h.strip() for h in reader.fieldnames or []]
         if columns is None:


### PR DESCRIPTION
## Summary
- ensure CSV reader handles optional UTF-8 BOM by opening files with `utf-8-sig`

## Testing
- `python scripts/process.py` *(fails: Відсутні файли DHCP у /workspace/Harvester-Prime/data/raw/dhcp. Обробку даних не запущено.)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a9f3bc49f4833187b569bd59c95673