### PR TITLE
Remove debug logging from ARM interim processing

### DIFF
--- a/scripts/process.py
+++ b/scripts/process.py
@@ -416,11 +416,7 @@ def run_arm_interim(arm_dir: Path, dhcp_file: Path, verified_file: Path) -> None
             file_count += 1
             columns = ["mac", "hostname", "owner", "pc_type", "randmac", "ownership"]
             rows = read_csv_mapped(path, "arm", columns)
-            print(f"DEBUG: Читання файлу {path}")
-            print(f"DEBUG: Стовпці: {columns}")
             for row in rows:
-                print(f"DEBUG: Ключі: {list(row.keys())}")
-                print(f"DEBUG: Дані: {row}")
                 mac_raw = (row.get("mac", "") or "").strip()
                 if MAC_RE.fullmatch(mac_raw):
                     mac = mac_raw.upper().replace("-", ":")
@@ -493,10 +489,6 @@ def run_arm_interim(arm_dir: Path, dhcp_file: Path, verified_file: Path) -> None
         "lastDate",
         "personal",
     ]
-    print(f"DEBUG: Запис до файлу {verified_file}")
-    print(f"DEBUG: Стовпці: {fieldnames}")
-    for row in rows_to_write:
-        print(f"DEBUG: Дані: {row}")
     file_created = write_csv(verified_file, fieldnames, rows_to_write, append=True)
     action = "Створено" if file_created else "Оновлено"
     print(f"{action} файл {verified_file}")


### PR DESCRIPTION
## Summary
- remove debug print statements when processing ARM verification data

## Testing
- `pytest -q` *(fails: No module named 'pandas')*
- `pip install pandas` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pip install pyyaml` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6541ce7c83319951c5ddbd9f74af