### PR TITLE
Add DHCP occurrence counts and randomized MAC detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Utilities for processing DHCP log files.
 
 * Collect DHCP log entries from CSV files in a directory.
 * Normalize records into a consistent structure.
-* Track the first and last times each MAC address appears in the logs.
+* Track how often each MAC address appears and the first/last timestamps.
+* Identify whether a MAC address is randomized (locally administered).
 * Write results to an interim CSV file while skipping duplicate rows.
 
 ## Input
@@ -17,7 +18,8 @@ Raw DHCP log CSV files. Locations are configurable via `configs/base.yaml` (defa
 
 A normalized CSV file containing unique DHCP records (default: `data/interim/dhcp.csv`).
 Each record includes the earliest (`firstDate`) and latest (`lastDate`) timestamps for
-when the MAC address was seen.
+when the MAC address was seen, how many times it appeared (`count`), and whether the
+MAC address is randomized (`randomized`).
 
 ## Usage
 
@@ -101,7 +103,7 @@ contain the listed columns. Columns are read as text unless noted otherwise.
 The processing steps produce these CSV files:
 
 - `data/interim/dhcp.csv` – columns: `source`, `ip`, `mac`, `name`,
-  `firstDate`, `lastDate`.
+  `firstDate`, `lastDate`, `count`, `randomized`.
 - `data/interim/verified.csv` – columns: `type`, `source`, `name`, `ip`,
   `mac`, `randmac`, `owner`, `note`, `firstDate`, `lastDate`, `personal`.
 - `data/interim/pending.csv` – columns: `type`, `source`, `ip`, `mac`,

--- a/configs/schemas.yml
+++ b/configs/schemas.yml
@@ -1,23 +1,44 @@
 arm:
-  # mac: "MAC"
-  # mac: "staticMac"
-  mac: "staticMac"
-  hostname: "hostname"
-  # owner: "owner"
-  owner: "owner"
-  pc_type: "pcType"
-  # pc_type: "Тип ПК"
-  ip: "ip"
-  # randmac: "randomMac"
-  randmac: "randomMac"
-  ownership: "pcOwning"
+  mac:
+    - "staticMac"
+    - "Static MAC"
+  hostname:
+    - "hostname"
+    - "Hostname"
+  owner:
+    - "owner"
+    - "Власник"
+  pc_type:
+    - "pcType"
+    - "Тип ПК"
+  ip:
+    - "ip"
+    - "IP"
+  randmac:
+    - "randomMac"
+    - "Random MAC"
+  ownership:
+    - "pcOwning"
+    - "Власність"
 mkp:
-  mac: "staticMac"
-  model: "model"
-  owner: "responsible"
-  mkp_type: "phoneType"
-  randmac: "randomMac"
-  category: "phoneCategory"
+  mac:
+    - "staticMac"
+    - "Статичний MAC"
+  model:
+    - "model"
+    - "Модель"
+  owner:
+    - "responsible"
+    - "Відповідальний"
+  mkp_type:
+    - "phoneType"
+    - "Тип МКП"
+  randmac:
+    - "randomMac"
+    - "Динамічний MAC"
+  category:
+    - "phoneCategory"
+    - "Категорія МКП"
 dhcp:
   mac: "mac"
   name: "name"
@@ -25,6 +46,8 @@ dhcp:
   firstDate: "firstDate"
   lastDate: "lastDate"
   source: "source"
+  count: "count"
+  randomized: "randomized"
 validation:
   ip: "ip"
   mac: "mac"

--- a/data/interim/dhcp.example.csv
+++ b/data/interim/dhcp.example.csv
@@ -1,2 +1,2 @@
-source,ip,mac,name,firstDate,lastDate
-10.0.0.10,192.168.0.10,AA:BB:CC:DD:EE:FF,Device1,1754562443848,1754562532771
+source,ip,mac,name,firstDate,lastDate,count,randomized
+10.0.0.10,192.168.0.10,AA:BB:CC:DD:EE:FF,Device1,1754562443848,1754562532771,1,true

--- a/scripts/process.py
+++ b/scripts/process.py
@@ -33,7 +33,7 @@ from app.collectors.files import (
     read_csv,
     write_csv,
 )
-from app.processors.normalize import normalize_dhcp_records
+from app.processors.normalize import normalize_dhcp_records, is_randomized_mac
 from app.processors.verified import append_other_to_verified
 
 
@@ -53,6 +53,12 @@ def load_schemas() -> dict:
 
 
 SCHEMAS = load_schemas()
+
+
+def _normalize_schema_key(value: str) -> str:
+    """Return a case-insensitive key without non-word characters."""
+
+    return re.sub(r"\W", "", (value or "").lower())
 
 
 def rename_hostname_column(path: Path) -> None:
@@ -88,11 +94,28 @@ def read_csv_mapped(path: Path, schema_key: str, columns: list[str]) -> list[dic
     if schema_key in {"dhcp", "pending"}:
         rename_hostname_column(path)
     mapping = SCHEMAS.get(schema_key, {})
-    actual_columns = [mapping.get(col, col) for col in columns]
-    rows = read_csv(path, columns=actual_columns)
+    rows = read_csv(path, columns=None)
     remapped = []
     for row in rows:
-        remapped.append({col: row.get(mapping.get(col, col), "") for col in columns})
+        normalised_row = {_normalize_schema_key(k): v for k, v in row.items()}
+        remapped_row: dict[str, str] = {}
+        for col in columns:
+            actual_values = mapping.get(col, col)
+            if not isinstance(actual_values, (list, tuple, set)):
+                actual_values = [actual_values]
+            value = ""
+            for actual in actual_values:
+                if actual in row:
+                    value = row.get(actual, "")
+                    if value is None:
+                        value = ""
+                    break
+                key = _normalize_schema_key(str(actual))
+                if key in normalised_row:
+                    value = normalised_row[key]
+                    break
+            remapped_row[col] = value
+        remapped.append(remapped_row)
     return remapped
 
 
@@ -364,6 +387,8 @@ def run_ubiq_interim(
                     "name": _normalize_name(row.get("name", ""), mac),
                     "firstDate": "",
                     "lastDate": _parse_last_date(row.get("date", ""), ip),
+                    "count": "",
+                    "randomized": "true" if is_randomized_mac(mac) else "false",
                 }
             )
 

--- a/src/app/collectors/files.py
+++ b/src/app/collectors/files.py
@@ -67,7 +67,16 @@ def write_dhcp_interim(path: Path, rows: Iterable[Dict[str, str]]) -> None:
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    fieldnames = ["source", "ip", "mac", "name", "firstDate", "lastDate"]
+    fieldnames = [
+        "source",
+        "ip",
+        "mac",
+        "name",
+        "firstDate",
+        "lastDate",
+        "count",
+        "randomized",
+    ]
 
     # Load existing records to avoid writing duplicates
     existing: Set[Tuple[str, ...]] = set()
@@ -103,6 +112,8 @@ def write_dhcp_interim(path: Path, rows: Iterable[Dict[str, str]]) -> None:
                 "name": row.get("name", row.get("hostname", "")),
                 "firstDate": row.get("firstDate", ""),
                 "lastDate": row.get("lastDate", ""),
+                "count": row.get("count", ""),
+                "randomized": row.get("randomized", ""),
             }
             record = tuple(normalized.get(f, "") for f in fieldnames)
             if record in existing:

--- a/src/app/processors/normalize.py
+++ b/src/app/processors/normalize.py
@@ -1,12 +1,42 @@
 """Functions for normalizing DHCP log data."""
 from __future__ import annotations
 
+from collections import Counter
 import re
 from typing import Dict, Iterable, List
 
 PAYLOAD_RE = re.compile(
     r"assigned\s+(?P<ip>\d+\.\d+\.\d+\.\d+)\s+for\s+(?P<mac>[0-9A-Fa-f:]{17})(?:\s+(?P<hostname>[^\s]+))?"
 )
+
+
+def _mac_key(value: str) -> str:
+    """Return a normalised key for *value* suitable for grouping."""
+
+    hex_only = re.sub(r"[^0-9A-Fa-f]", "", value or "").upper()
+    return hex_only or (value or "").strip().upper()
+
+
+def _format_mac(value: str) -> str:
+    """Return *value* formatted as ``XX:XX:XX:XX:XX:XX`` when possible."""
+
+    hex_only = re.sub(r"[^0-9A-Fa-f]", "", value or "").upper()
+    if len(hex_only) != 12:
+        return (value or "").strip()
+    return ":".join(hex_only[i : i + 2] for i in range(0, 12, 2))
+
+
+def is_randomized_mac(value: str) -> bool:
+    """Return ``True`` if *value* is a locally administered MAC address."""
+
+    hex_only = re.sub(r"[^0-9A-Fa-f]", "", value or "")
+    if len(hex_only) < 2:
+        return False
+    try:
+        first_octet = int(hex_only[:2], 16)
+    except ValueError:
+        return False
+    return bool(first_octet & 0x02)
 
 
 def parse_payload(payload: str) -> Dict[str, str]:
@@ -24,7 +54,7 @@ def deduplicate_by_mac(records: Iterable[Dict[str, str]]) -> List[Dict[str, str]
     """Return only the latest record for each MAC address."""
     latest: Dict[str, Dict[str, str]] = {}
     for record in records:
-        mac = record.get("sourcMACAddress", "")
+        mac = _mac_key(record.get("sourcMACAddress", ""))
         time_str = record.get("deviceTime", "0")
         try:
             timestamp = int(time_str)
@@ -58,30 +88,35 @@ def normalize_dhcp_records(records: Iterable[Dict[str, str]]) -> List[Dict[str, 
     # ``records`` may be an iterator; convert to list so we can iterate twice
     records = list(records)
 
-    # Determine the earliest timestamp for each MAC address
+    # Determine the earliest timestamp and occurrence count for each MAC address
     first_seen: Dict[str, str] = {}
+    occurrences: Counter[str] = Counter()
     for record in records:
-        mac = record.get("sourcMACAddress", "")
+        mac_key = _mac_key(record.get("sourcMACAddress", ""))
         time_str = record.get("deviceTime", "0")
         try:
             ts = int(time_str)
         except ValueError:
             ts = 0
-        if mac not in first_seen or ts < int(first_seen.get(mac, ts)):
-            first_seen[mac] = time_str
+        if mac_key not in first_seen or ts < int(first_seen.get(mac_key, ts)):
+            first_seen[mac_key] = time_str
+        occurrences[mac_key] += 1
 
     normalized: List[Dict[str, str]] = []
     for record in deduplicate_by_mac(records):
         payload = parse_payload(record.get("payloadAsUTF", ""))
-        mac = payload.get("mac", record.get("sourcMACAddress", ""))
+        mac = _format_mac(payload.get("mac", record.get("sourcMACAddress", "")))
+        mac_key = _mac_key(mac)
         normalized.append(
             {
                 "source": record.get("logSourceIdentifier", ""),
                 "ip": payload.get("ip", ""),
                 "mac": mac,
                 "hostname": payload.get("hostname", "unknown"),
-                "firstDate": first_seen.get(mac, ""),
+                "firstDate": first_seen.get(mac_key, ""),
                 "lastDate": record.get("deviceTime", ""),
+                "count": str(occurrences.get(mac_key, 0)),
+                "randomized": "true" if is_randomized_mac(mac) else "false",
             }
         )
     return normalized

--- a/tests/test_append_other_to_verified.py
+++ b/tests/test_append_other_to_verified.py
@@ -28,8 +28,8 @@ def test_append_and_idempotent(tmp_path: Path) -> None:
     )
 
     dhcp_file.write_text(
-        "source,ip,mac,firstDate,lastDate\n"
-        "s1,10.0.0.1,AA:BB:CC:DD:EE:FF,1,2\n",
+        "source,ip,mac,firstDate,lastDate,count,randomized\n"
+        "s1,10.0.0.1,AA:BB:CC:DD:EE:FF,1,2,1,false\n",
         encoding="utf-8",
     )
 

--- a/tests/test_ignore_mac.py
+++ b/tests/test_ignore_mac.py
@@ -39,3 +39,5 @@ def test_ignore_mac(tmp_path, monkeypatch):
         rows = list(csv.DictReader(fh))
 
     assert [row["mac"] for row in rows] == ["11:22:33:44:55:66"]
+    assert rows[0]["count"] == "1"
+    assert rows[0]["randomized"] == "false"

--- a/tests/test_random_dynamic_verified.py
+++ b/tests/test_random_dynamic_verified.py
@@ -29,8 +29,8 @@ def test_rarm_and_idempotent(tmp_path: Path) -> None:
     )
 
     dhcp_file.write_text(
-        "source,ip,mac,firstDate,lastDate\n"
-        "s1,10.0.0.1,B1:67:2D:F4:CA:49,1,2\n",
+        "source,ip,mac,firstDate,lastDate,count,randomized\n"
+        "s1,10.0.0.1,B1:67:2D:F4:CA:49,1,2,1,false\n",
         encoding="utf-8",
     )
 
@@ -63,8 +63,8 @@ def test_rmkp_and_idempotent(tmp_path: Path) -> None:
     )
 
     dhcp_file.write_text(
-        "source,ip,mac,firstDate,lastDate\n"
-        "s1,10.0.0.2,DE:E4:16:AC:71:FE,3,4\n",
+        "source,ip,mac,firstDate,lastDate,count,randomized\n"
+        "s1,10.0.0.2,DE:E4:16:AC:71:FE,3,4,1,true\n",
         encoding="utf-8",
     )
 

--- a/tests/test_ubiq_processing.py
+++ b/tests/test_ubiq_processing.py
@@ -31,6 +31,8 @@ def test_run_ubiq_interim(tmp_path):
             "name": "unknown",
             "firstDate": "",
             "lastDate": "",
+            "count": "",
+            "randomized": "true",
         },
         {
             "source": "192.168.55.1",
@@ -39,5 +41,7 @@ def test_run_ubiq_interim(tmp_path):
             "name": "A36-phone",
             "firstDate": "",
             "lastDate": "1755492240",
+            "count": "",
+            "randomized": "false",
         },
     ]


### PR DESCRIPTION
## Summary
- augment DHCP normalization to calculate occurrence counts and flag randomized MAC addresses
- extend CSV writing, schemas, and examples/tests to include the new columns
- enhance schema mapping to support multiple header variants when reading source files

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc4b9899e483318ee9b895372e6375