### PR TITLE
Add randomized MAC note to report1 output

### DIFF
--- a/scripts/generate_report1.py
+++ b/scripts/generate_report1.py
@@ -47,7 +47,9 @@ def read_rows(path: Path) -> list[dict[str, str]]:
 
 
 def build_verified_rows(
-    devices: list[tuple[str, str]], rows: list[dict[str, str]]
+    devices: list[tuple[str, str]],
+    rows: list[dict[str, str]],
+    randomized_macs: set[str],
 ) -> list[dict[str, str]]:
     """Create report rows for verified devices ordered by device keys."""
     report_rows: list[dict[str, str]] = []
@@ -67,6 +69,9 @@ def build_verified_rows(
                 note_parts.append(
                     f"На пристрої ввімкнено генерацію випадкової MAC-адреси - {randmac_val}"
                 )
+            if row.get("mac", "").upper() in randomized_macs:
+                note_parts.append("MAC-адреса рандомна (U/L=1).")
+
             note = "\n".join(note_parts)
 
             personal_val = row.get("personal", "").lower()
@@ -122,7 +127,9 @@ def _format_dt(value: str) -> str:
 
 
 def build_pending_rows(
-    devices: list[tuple[str, str]], rows: list[dict[str, str]]
+    devices: list[tuple[str, str]],
+    rows: list[dict[str, str]],
+    randomized_macs: set[str],
 ) -> list[dict[str, str]]:
     """Create report rows for pending devices ordered by device keys."""
     report_rows: list[dict[str, str]] = []
@@ -149,6 +156,9 @@ def build_pending_rows(
             elif not first and last:
                 last_fmt = _format_dt(last)
                 note_parts.append(f"Останнє підключення – {last_fmt}.")
+            if row.get("mac", "").upper() in randomized_macs:
+                note_parts.append("MAC-адреса рандомна (U/L=1).")
+
             note = "\n".join(note_parts)
             report_rows.append(
                 {
@@ -201,6 +211,15 @@ def main() -> None:
     devices = load_device_mapping()
     verified_path = BASE_DIR / "data" / "interim" / "verified.csv"
     pending_path = BASE_DIR / "data" / "interim" / "pending.csv"
+    dhcp_path = BASE_DIR / "data" / "interim" / "dhcp.csv"
+
+    randomized_macs: set[str] = set()
+    if dhcp_path.exists():
+        for row in read_rows(dhcp_path):
+            mac = row.get("mac", "").upper()
+            randomized = row.get("randomized", "").strip().lower()
+            if mac and randomized == "true":
+                randomized_macs.add(mac)
 
     if verified_path.exists():
         verified_rows = read_rows(verified_path)
@@ -214,8 +233,8 @@ def main() -> None:
         print(f"Файл {pending_path} не знайдено")
         pending_rows = []
 
-    report_rows = build_verified_rows(devices, verified_rows)
-    report_rows.extend(build_pending_rows(devices, pending_rows))
+    report_rows = build_verified_rows(devices, verified_rows, randomized_macs)
+    report_rows.extend(build_pending_rows(devices, pending_rows, randomized_macs))
     report_path = BASE_DIR / "data" / "interim" / "report1.csv"
     added = write_report(report_rows, report_path)
     print(f"Створено файл {report_path}")

--- a/tests/test_generate_report1_pending.py
+++ b/tests/test_generate_report1_pending.py
@@ -136,3 +136,59 @@ def test_generate_report1_handles_last_date_only(tmp_path, monkeypatch):
         == "Не надано для перевірки.\nОстаннє підключення – 03.02.2024 04:05."
     )
 
+
+def test_generate_report1_includes_randomized_note(tmp_path, monkeypatch):
+    base_dir = tmp_path
+
+    (base_dir / "configs").mkdir()
+    (base_dir / "data" / "interim").mkdir(parents=True)
+    (base_dir / "configs" / "base.yaml").write_text(
+        """devices:
+  router: "Маршрутизатор"
+  arm: "АРМ"
+""",
+        encoding="utf-8",
+    )
+
+    (base_dir / "data" / "interim" / "verified.csv").write_text(
+        "source,type,name,ip,mac,randmac,note,personal\n"
+        "VSrc,router,RName,1.1.1.1,AA:BB:CC:DD:EE:FF,,,\n",
+        encoding="utf-8",
+    )
+
+    (base_dir / "data" / "interim" / "pending.csv").write_text(
+        "source,name,ip,mac,randmac,type,firstDate,lastDate\n"
+        "PSrc,PName,2.2.2.2,11:22:33:44:55:66,,arm,2024-01-02 03:04,2024-02-03 04:05\n",
+        encoding="utf-8",
+    )
+
+    (base_dir / "data" / "interim" / "dhcp.csv").write_text(
+        "source,ip,mac,name,firstDate,lastDate,count,randomized\n"
+        "s1,1.1.1.1,AA:BB:CC:DD:EE:FF,,0,0,1,true\n"
+        "s2,2.2.2.2,11:22:33:44:55:66,,0,0,1,true\n",
+        encoding="utf-8",
+    )
+
+    gr = importlib.import_module("scripts.generate_report1")
+    monkeypatch.setattr(gr, "BASE_DIR", base_dir)
+    gr.main()
+
+    report_path = base_dir / "data" / "interim" / "report1.csv"
+    with open(report_path, encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+
+    assert len(rows) == 2
+    verified = rows[0]
+    pending = rows[1]
+
+    assert (
+        verified["note"]
+        == "Надано на перевірку.\nMAC-адреса рандомна (U/L=1)."
+    )
+    assert (
+        pending["note"]
+        == "Не надано для перевірки.\n"
+        "Перше підключення – 02.01.2024 03:04, останнє підключення – 03.02.2024 04:05.\n"
+        "MAC-адреса рандомна (U/L=1)."
+    )
+


### PR DESCRIPTION
## Summary
- add detection of randomized MACs from data/interim/dhcp.csv when generating report1
- append "MAC-адреса рандомна (U/L=1)." to the note field for matching verified and pending rows
- cover the new behaviour with a regression test for verified and pending entries

## Testing
- pytest tests/test_generate_report1_pending.py

------
https://chatgpt.com/codex/tasks/task_e_68dc50bd2dac833187ec98e91e197a20