### PR TITLE
Default process cleanup and trigger report generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ python scripts/process.py
 
 The script reads configuration, processes the raw logs and stores the normalized output.
 
+By default the command clears existing CSVs in `data/interim` (the same effect as
+running `python scripts/process.py clean`) and, after processing, automatically
+invokes `scripts/generate_report1.py` to rebuild `data/result/report1.csv`.
+
 See `src/app/collectors/files.py` for implementation details.
 
 ## Configuration
@@ -78,25 +82,31 @@ contain the listed columns. Columns are read as text unless noted otherwise.
 
 `scripts/process.py` performs the following operations in sequence:
 
-1. **Normalize DHCP logs** – read `data/raw/dhcp` and write unique records
+1. **Clean interim data** – remove CSVs in `data/interim` (except
+   `*.example.csv`) to ensure a fresh run. This happens automatically even
+   without passing the `clean` argument.
+2. **Normalize DHCP logs** – read `data/raw/dhcp` and write unique records
    to `data/interim/dhcp.csv`.
-2. **Append Ubiq data** – convert Ubiq CSVs and add them to the interim DHCP
+3. **Append Ubiq data** – convert Ubiq CSVs and add them to the interim DHCP
    file.
-3. **Validation check** – compare MACs from `data/raw/validation` with the
-   DHCP list and write a report to `data/result/report1.csv`.
-4. **ARM interim** – match ARM inventory MACs with DHCP data and append
+4. **Validation check** – compare MACs from `data/raw/validation` with the
+   DHCP list and write a report to the configured validation path
+   (default: `data/result/report1.csv`).
+5. **ARM interim** – match ARM inventory MACs with DHCP data and append
    matches to `data/interim/verified.csv` with `type="arm"`.
-5. **MKP interim** – match MKP inventory MACs with DHCP data and append
+6. **MKP interim** – match MKP inventory MACs with DHCP data and append
    matches to the same verified file with `type="mkp"` and optional
    `randmac`.
-6. **Other devices** – append entries from `data/raw/other` to
+7. **Other devices** – append entries from `data/raw/other` to
    `data/interim/verified.csv` when their MAC is present in DHCP data.
-7. **ARM & MKP reports** – create `data/result/120report2.csv` comparing ARM
+8. **ARM & MKP reports** – create `data/result/120report2.csv` comparing ARM
    and MKP inventories against DHCP data; new rows include `name`, `ipmac`,
    `owner` and `note`.
-8. **Pending devices** – write DHCP records absent from the verified list to
+9. **Pending devices** – write DHCP records absent from the verified list to
    `data/interim/pending.csv` with a device `type` inferred from the host
    name.
+10. **Generate report1** – run `scripts/generate_report1.py` to combine
+    verified and pending records into `data/result/report1.csv`.
 
 ## Result files
 
@@ -108,5 +118,6 @@ The processing steps produce these CSV files:
   `mac`, `randmac`, `owner`, `note`, `firstDate`, `lastDate`, `personal`.
 - `data/interim/pending.csv` – columns: `type`, `source`, `ip`, `mac`,
   `name`, `firstDate`, `lastDate`.
-- `data/result/report1.csv` – columns: `name`, `ipmac`, `note`.
+- `data/result/report1.csv` – combined verified and pending report with
+  columns: `name`, `ipmac`, `note`.
 - `data/result/120report2.csv` – columns: `name`, `ipmac`, `owner`, `note`.

--- a/scripts/generate_report1.py
+++ b/scripts/generate_report1.py
@@ -246,7 +246,7 @@ def main() -> None:
 
     report_rows = build_verified_rows(devices, verified_rows, randomized_macs)
     report_rows.extend(build_pending_rows(devices, pending_rows, randomized_macs))
-    report_path = BASE_DIR / "data" / "interim" / "report1.csv"
+    report_path = BASE_DIR / "data" / "result" / "report1.csv"
     added = write_report(report_rows, report_path)
     print(f"Створено файл {report_path}")
     print(f"Додано {added} записів")

--- a/scripts/process.py
+++ b/scripts/process.py
@@ -920,8 +920,9 @@ def clean_interim(directory: Path | None = None) -> None:
 def main(argv: list[str] | None = None) -> None:
     argv = list(argv or sys.argv[1:])
     if argv and argv[0] == "clean":
-        clean_interim()
         argv = argv[1:]
+
+    clean_interim()
 
     config = load_config()
     paths = config.get("paths", {})
@@ -977,6 +978,13 @@ def main(argv: list[str] | None = None) -> None:
     run_mkp_check(mkp_dir, interim_file, report_file2)
     pending_file = BASE_DIR / "data/interim/pending.csv"
     run_pending_check(interim_file, verified_file, pending_file)
+
+    try:
+        from scripts import generate_report1
+    except Exception as exc:  # pragma: no cover - defensive logging
+        print(f"Не вдалося згенерувати звіт: {exc}")
+    else:
+        generate_report1.main()
 
 
 if __name__ == "__main__":

--- a/tests/test_generate_report1_pending.py
+++ b/tests/test_generate_report1_pending.py
@@ -37,7 +37,7 @@ def test_generate_report1_includes_pending(tmp_path, monkeypatch):
     monkeypatch.setattr(gr, "BASE_DIR", base_dir)
     gr.main()
 
-    report_path = base_dir / "data" / "interim" / "report1.csv"
+    report_path = base_dir / "data" / "result" / "report1.csv"
     with open(report_path, encoding="utf-8") as fh:
         rows = list(csv.DictReader(fh))
 
@@ -84,7 +84,7 @@ def test_generate_report1_handles_epoch_times(tmp_path, monkeypatch):
     monkeypatch.setattr(gr, "BASE_DIR", base_dir)
     gr.main()
 
-    report_path = base_dir / "data" / "interim" / "report1.csv"
+    report_path = base_dir / "data" / "result" / "report1.csv"
     with open(report_path, encoding="utf-8") as fh:
         rows = list(csv.DictReader(fh))
 
@@ -125,7 +125,7 @@ def test_generate_report1_handles_last_date_only(tmp_path, monkeypatch):
     monkeypatch.setattr(gr, "BASE_DIR", base_dir)
     gr.main()
 
-    report_path = base_dir / "data" / "interim" / "report1.csv"
+    report_path = base_dir / "data" / "result" / "report1.csv"
     with open(report_path, encoding="utf-8") as fh:
         rows = list(csv.DictReader(fh))
 
@@ -173,7 +173,7 @@ def test_generate_report1_includes_randomized_note(tmp_path, monkeypatch):
     monkeypatch.setattr(gr, "BASE_DIR", base_dir)
     gr.main()
 
-    report_path = base_dir / "data" / "interim" / "report1.csv"
+    report_path = base_dir / "data" / "result" / "report1.csv"
     with open(report_path, encoding="utf-8") as fh:
         rows = list(csv.DictReader(fh))
 
@@ -183,12 +183,12 @@ def test_generate_report1_includes_randomized_note(tmp_path, monkeypatch):
 
     assert (
         verified["note"]
-        == "Надано на перевірку.\nMAC-адреса рандомна (U/L=1)."
+        == "Надано на перевірку.\nНа пристрої увімкнена генерація випадкової MAC-адреси."
     )
     assert (
         pending["note"]
         == "Не надано для перевірки.\n"
-        "Перше підключення – 02.01.2024 03:04, останнє підключення – 03.02.2024 04:05.\n"
-        "MAC-адреса рандомна (U/L=1)."
+        "На пристрої увімкнена генерація випадкової MAC-адреси.\n"
+        "Перше підключення – 02.01.2024 03:04, останнє підключення – 03.02.2024 04:05."
     )
 

--- a/tests/test_personal_note.py
+++ b/tests/test_personal_note.py
@@ -27,7 +27,7 @@ def test_personal_suffix_in_note(tmp_path, monkeypatch):
     monkeypatch.setattr(gr, "BASE_DIR", base_dir)
     gr.main()
 
-    report_path = base_dir / "data" / "interim" / "report1.csv"
+    report_path = base_dir / "data" / "result" / "report1.csv"
     with open(report_path, encoding="utf-8") as fh:
         rows = list(csv.DictReader(fh))
 


### PR DESCRIPTION
## Summary
- ensure `scripts/process.py` always clears interim CSVs before processing and automatically runs the report generator
- move the `generate_report1` output to `data/result/report1.csv` and document the new behaviour in the README
- adjust tests to reflect the new report location and current random-MAC messaging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f5f126ae0c8331a5ce4542d8a6e2ce