### PR TITLE
Fix scripts package import in process script

### DIFF
--- a/scripts/process.py
+++ b/scripts/process.py
@@ -22,9 +22,13 @@ try:
 except Exception:  # pragma: no cover
     yaml = None  # type: ignore
 
-# Ensure the src directory is on the Python path
+# Ensure the repository root and ``src`` directory are on the Python path
 BASE_DIR = Path(__file__).resolve().parent.parent
-sys.path.append(str(BASE_DIR / "src"))
+
+for path in (BASE_DIR, BASE_DIR / "src"):
+    path_str = str(path)
+    if path_str not in sys.path:
+        sys.path.append(path_str)
 
 from app.collectors.files import (
     load_dhcp_logs,


### PR DESCRIPTION
## Summary
- ensure the repository root is placed on sys.path when running scripts/process.py
- keep adding the src directory while preventing duplicate path entries

## Testing
- python3 scripts/process.py

------
https://chatgpt.com/codex/tasks/task_e_68f5f37822348331ae97a1d064c5ad73