### PR TITLE
Ensure remote device types include required note

### DIFF
--- a/scripts/generate_report1.py
+++ b/scripts/generate_report1.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 EXCLUDED_RANDOMIZED_TYPES = {"rarm", "rmkp"}
+SPECIAL_NOTE_TYPES = {"rmkp", "rarm"}
 
 
 def load_device_mapping() -> list[tuple[str, str]]:
@@ -64,19 +65,27 @@ def build_verified_rows(
                 name_parts.append(note_val)
             name = "\n".join(name_parts)
             ipmac = f"{row.get('ip', '')}\n{row.get('mac', '')}"
-            note_parts = ["Надано на перевірку."]
-            randmac_val = row.get("randmac", "")
-            if randmac_val:
-                note_parts.append(
-                    f"На пристрої ввімкнено генерацію випадкової MAC-адреси - {randmac_val}"
-                )
-            if (
-                row.get("mac", "").upper() in randomized_macs
-                and key not in EXCLUDED_RANDOMIZED_TYPES
-            ):
-                note_parts.insert(
-                    1, "На пристрої увімкнена генерація випадкової MAC-адреси."
-                )
+            if key in SPECIAL_NOTE_TYPES:
+                note_parts = [
+                    "Не додавати до додатку 1.",
+                    "Надано на перевірку.",
+                    "На пристрої ввімкнено генерацію випадкової MAC-адреси",
+                ]
+            else:
+                note_parts = ["Надано на перевірку."]
+                randmac_val = row.get("randmac", "")
+                if randmac_val:
+                    note_parts.append(
+                        "На пристрої ввімкнено генерацію випадкової MAC-адреси"
+                        f" - {randmac_val}"
+                    )
+                if (
+                    row.get("mac", "").upper() in randomized_macs
+                    and key not in EXCLUDED_RANDOMIZED_TYPES
+                ):
+                    note_parts.insert(
+                        1, "На пристрої увімкнена генерація випадкової MAC-адреси."
+                    )
 
             note = "\n".join(note_parts)
 
@@ -167,7 +176,15 @@ def build_pending_rows(
                 continue
             name = f"{display_name}\n{row.get('name', '')}"
             ipmac = f"{row.get('ip', '')}\n{row.get('mac', '')}"
-            note_parts = ["Не надано для перевірки."]
+            note_parts: list[str]
+            if key in SPECIAL_NOTE_TYPES:
+                note_parts = [
+                    "Не додавати до додатку 1.",
+                    "Надано на перевірку.",
+                    "На пристрої ввімкнено генерацію випадкової MAC-адреси",
+                ]
+            else:
+                note_parts = ["Не надано для перевірки."]
             first = row.get("firstDate", "")
             last = row.get("lastDate", "")
             first_fmt, first_epoch = _parse_timestamp(first)
@@ -186,6 +203,7 @@ def build_pending_rows(
             if (
                 row.get("mac", "").upper() in randomized_macs
                 and key not in EXCLUDED_RANDOMIZED_TYPES
+                and key not in SPECIAL_NOTE_TYPES
             ):
                 note_parts.insert(
                     1, "На пристрої увімкнена генерація випадкової MAC-адреси."

--- a/tests/test_generate_report1_pending.py
+++ b/tests/test_generate_report1_pending.py
@@ -62,6 +62,57 @@ def test_generate_report1_includes_pending(tmp_path, monkeypatch):
     assert pending["lastConnectEpoch"] == "1706933100"
 
 
+def test_generate_report1_special_note_for_remote_types(tmp_path, monkeypatch):
+    base_dir = tmp_path
+
+    (base_dir / "configs").mkdir()
+    (base_dir / "data" / "interim").mkdir(parents=True)
+    (base_dir / "configs" / "base.yaml").write_text(
+        """devices:
+  router: "Маршрутизатор"
+  rmkp: "РМКП"
+  rarm: "РАРМ"
+""",
+        encoding="utf-8",
+    )
+
+    (base_dir / "data" / "interim" / "verified.csv").write_text(
+        "source,type,name,ip,mac,randmac,note,personal\n"
+        "VSrc,rmkp,RName,1.1.1.1,AA:BB:CC:DD:EE:FF,,,\n",
+        encoding="utf-8",
+    )
+
+    (base_dir / "data" / "interim" / "pending.csv").write_text(
+        "source,name,ip,mac,randmac,type,firstDate,lastDate\n"
+        "PSrc,PName,2.2.2.2,11:22:33:44:55:66,,rarm,2024-01-02 03:04,2024-02-03 04:05\n",
+        encoding="utf-8",
+    )
+
+    gr = importlib.import_module("scripts.generate_report1")
+    monkeypatch.setattr(gr, "BASE_DIR", base_dir)
+    gr.main()
+
+    report_path = base_dir / "data" / "result" / "report1.csv"
+    with open(report_path, encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+
+    assert len(rows) == 2
+
+    rmkp_row = next(row for row in rows if row["type"] == "rmkp")
+    rarm_row = next(row for row in rows if row["type"] == "rarm")
+
+    expected_note = (
+        "Не додавати до додатку 1.\n"
+        "Надано на перевірку.\n"
+        "На пристрої ввімкнено генерацію випадкової MAC-адреси"
+    )
+
+    assert rmkp_row["note"] == expected_note
+    assert rarm_row["note"].startswith(expected_note)
+    assert "Перше підключення – 02.01.2024 03:04" in rarm_row["note"]
+    assert "останнє підключення – 03.02.2024 04:05." in rarm_row["note"]
+
+
 def test_generate_report1_handles_epoch_times(tmp_path, monkeypatch):
     base_dir = tmp_path
 


### PR DESCRIPTION
## Summary
- ensure report1 assigns the mandated note text to rmkp and rarm device rows
- prevent randomized MAC notices from overriding the mandated copy and keep other note logic intact
- add regression coverage verifying the new note behavior for rmkp and rarm entries

## Testing
- pytest tests/test_generate_report1_pending.py

------
https://chatgpt.com/codex/tasks/task_e_68f6039702288331907c77d1d2660fa4