### PR TITLE
Add ownership column to report1 output

### DIFF
--- a/scripts/generate_report1.py
+++ b/scripts/generate_report1.py
@@ -92,11 +92,14 @@ def build_verified_rows(
             first_fmt, first_epoch = _parse_timestamp(row.get("firstDate", ""))
             last_fmt, last_epoch = _parse_timestamp(row.get("lastDate", ""))
 
-            personal_val = row.get("personal", "").lower()
+            personal_val = row.get("personal", "").strip().lower()
+            ownership = ""
             if personal_val == "true":
                 suffix = "Пристрій особистий."
+                ownership = "особистий"
             elif personal_val == "false":
                 suffix = "Пристрій службовий."
+                ownership = "службовий"
             else:
                 suffix = ""
 
@@ -122,6 +125,7 @@ def build_verified_rows(
                     "lastConnect": last_fmt,
                     "firstConnectEpoch": first_epoch,
                     "lastConnectEpoch": last_epoch,
+                    "ownership": ownership,
                 }
             )
     return report_rows
@@ -222,6 +226,7 @@ def build_pending_rows(
                     "lastConnect": last_fmt if last else "",
                     "firstConnectEpoch": first_epoch if first else "",
                     "lastConnectEpoch": last_epoch if last else "",
+                    "ownership": "none",
                 }
             )
     return report_rows
@@ -237,6 +242,7 @@ def write_report(rows: list[dict[str, str]], path: Path) -> int:
     fieldnames = [
         "source",
         "verified",
+        "ownership",
         "type",
         "name",
         "ipmac",

--- a/tests/test_generate_report1_pending.py
+++ b/tests/test_generate_report1_pending.py
@@ -45,6 +45,7 @@ def test_generate_report1_includes_pending(tmp_path, monkeypatch):
     verified = rows[0]
     pending = rows[1]
     assert pending["verified"] == "false"
+    assert pending["ownership"] == "none"
     assert pending["type"] == "arm"
     assert pending["name"] == "АРМ\nPName"
     assert pending["ipmac"] == "2.2.2.2\nbb"
@@ -60,6 +61,7 @@ def test_generate_report1_includes_pending(tmp_path, monkeypatch):
     assert pending["lastConnect"] == "03.02.2024 04:05"
     assert pending["firstConnectEpoch"] == "1704164640"
     assert pending["lastConnectEpoch"] == "1706933100"
+    assert verified["ownership"] == "службовий"
 
 
 def test_generate_report1_special_note_for_remote_types(tmp_path, monkeypatch):
@@ -111,6 +113,8 @@ def test_generate_report1_special_note_for_remote_types(tmp_path, monkeypatch):
     assert rarm_row["note"].startswith(expected_note)
     assert "Перше підключення – 02.01.2024 03:04" in rarm_row["note"]
     assert "останнє підключення – 03.02.2024 04:05." in rarm_row["note"]
+    assert rmkp_row["ownership"] == ""
+    assert rarm_row["ownership"] == "none"
 
 
 def test_generate_report1_handles_epoch_times(tmp_path, monkeypatch):
@@ -158,6 +162,7 @@ def test_generate_report1_handles_epoch_times(tmp_path, monkeypatch):
     assert pending["lastConnect"] == "03.02.2024 04:05"
     assert pending["firstConnectEpoch"] == "1704164640"
     assert pending["lastConnectEpoch"] == "1706933100"
+    assert pending["ownership"] == "none"
 
 
 def test_generate_report1_handles_last_date_only(tmp_path, monkeypatch):

--- a/tests/test_personal_note.py
+++ b/tests/test_personal_note.py
@@ -39,3 +39,5 @@ def test_personal_suffix_in_note(tmp_path, monkeypatch):
         rows[1]["note"]
         == "Надано на перевірку. Пристрій службовий. Заявка на підключення до локальних мереж, складена, МАС-адреса закріплена за ІР-адресою."
     )
+    assert rows[0]["ownership"] == "особистий"
+    assert rows[1]["ownership"] == "службовий"


### PR DESCRIPTION
## Summary
- add an ownership column to generated report1.csv rows based on the personal flag
- default pending report entries to an ownership of "none" and persist the new column in report output
- extend report generation tests to cover the ownership field values

## Testing
- pytest tests/test_generate_report1_pending.py tests/test_personal_note.py

------
https://chatgpt.com/codex/tasks/task_e_68f607c50f8c8331babebf052f97417e