### PR TITLE
Add informsystem column to generated report1 data

### DIFF
--- a/data/result/report1.csv
+++ b/data/result/report1.csv
@@ -1,0 +1,1 @@
+source,verified,ownership,informsystem,type,name,ipmac,note,firstConnect,lastConnect,firstConnectEpoch,lastConnectEpoch

--- a/scripts/generate_report1.py
+++ b/scripts/generate_report1.py
@@ -36,6 +36,54 @@ def load_device_mapping() -> list[tuple[str, str]]:
     return devices
 
 
+def load_informsystem_mapping() -> dict[str, str]:
+    """Return mapping from note values to information system names."""
+
+    mapping: dict[str, str] = {}
+    config_path: Path | None = None
+    for filename in ("local.yaml", "local.yml"):
+        path = BASE_DIR / "configs" / filename
+        if path.exists():
+            config_path = path
+            break
+
+    if config_path is None:
+        return mapping
+
+    in_apps = False
+    current_source: str | None = None
+    with open(config_path, encoding="utf-8") as fh:
+        for line in fh:
+            stripped = line.rstrip("\n")
+            if not in_apps:
+                if stripped.strip() == "apps:":
+                    in_apps = True
+                continue
+
+            if not stripped.strip():
+                continue
+
+            if not stripped.startswith("  "):
+                if in_apps:
+                    break
+                continue
+
+            if stripped.startswith("    "):
+                key, _, raw_value = stripped.strip().partition(":")
+                value = raw_value.strip().strip('"\'')
+                if key == "source":
+                    current_source = value
+                elif key == "target" and current_source is not None:
+                    mapping[current_source.lower()] = value
+                    if value:
+                        mapping[value.lower()] = value
+            else:
+                current_source = None
+                continue
+
+    return mapping
+
+
 def read_rows(path: Path) -> list[dict[str, str]]:
     """Read CSV ensuring all fields are strings."""
     rows: list[dict[str, str]] = []
@@ -52,6 +100,7 @@ def build_verified_rows(
     devices: list[tuple[str, str]],
     rows: list[dict[str, str]],
     randomized_macs: set[str],
+    informsystem_mapping: dict[str, str],
 ) -> list[dict[str, str]]:
     """Create report rows for verified devices ordered by device keys."""
     report_rows: list[dict[str, str]] = []
@@ -61,8 +110,12 @@ def build_verified_rows(
                 continue
             name_parts = [display_name, row.get("name", "")]
             note_val = row.get("note", "")
-            if note_val:
-                name_parts.append(note_val)
+            informsystem, remaining_note = _extract_informsystem(
+                note_val, informsystem_mapping
+            )
+            if remaining_note:
+                name_parts.append(remaining_note)
+            informsystem_value = informsystem or "none"
             name = "\n".join(name_parts)
             ipmac = f"{row.get('ip', '')}\n{row.get('mac', '')}"
             if key in SPECIAL_NOTE_TYPES:
@@ -126,6 +179,7 @@ def build_verified_rows(
                     "firstConnectEpoch": first_epoch,
                     "lastConnectEpoch": last_epoch,
                     "ownership": ownership,
+                    "informsystem": informsystem_value,
                 }
             )
     return report_rows
@@ -227,9 +281,50 @@ def build_pending_rows(
                     "firstConnectEpoch": first_epoch if first else "",
                     "lastConnectEpoch": last_epoch if last else "",
                     "ownership": "none",
+                    "informsystem": "none",
                 }
             )
     return report_rows
+
+
+def _extract_informsystem(
+    note: str, mapping: dict[str, str]
+) -> tuple[str, str]:
+    """Return informsystem value and remaining note for *note* using *mapping*."""
+
+    note = note or ""
+    normalized = note.replace("\r\n", "\n").replace("\r", "\n")
+    parts = [part.strip() for part in normalized.split("\n") if part.strip()]
+
+    if not parts:
+        return "", ""
+
+    matched_values: list[str] = []
+    matched_keys: set[str] = set()
+    unmatched_parts: list[str] = []
+    matched_any = False
+
+    for part in parts:
+        key = part.lower()
+        target = mapping.get(key)
+        if target is not None:
+            matched_any = True
+            target = target.strip()
+            if target:
+                normalized_target = target
+                target_key = normalized_target.lower()
+                if target_key not in matched_keys:
+                    matched_keys.add(target_key)
+                    matched_values.append(normalized_target)
+        else:
+            unmatched_parts.append(part)
+
+    if not matched_any:
+        return "", note
+
+    remaining_note = "\n".join(unmatched_parts)
+    informsystem_value = "\n".join(matched_values)
+    return informsystem_value, remaining_note
 
 
 def write_report(rows: list[dict[str, str]], path: Path) -> int:
@@ -243,6 +338,7 @@ def write_report(rows: list[dict[str, str]], path: Path) -> int:
         "source",
         "verified",
         "ownership",
+        "informsystem",
         "type",
         "name",
         "ipmac",
@@ -313,7 +409,10 @@ def main() -> None:
         print(f"Файл {pending_path} не знайдено")
         pending_rows = []
 
-    report_rows = build_verified_rows(devices, verified_rows, randomized_macs)
+    informsystem_mapping = load_informsystem_mapping()
+    report_rows = build_verified_rows(
+        devices, verified_rows, randomized_macs, informsystem_mapping
+    )
     report_rows.extend(build_pending_rows(devices, pending_rows, randomized_macs))
     report_path = BASE_DIR / "data" / "result" / "report1.csv"
     added = write_report(report_rows, report_path)

--- a/tests/test_generate_report1_pending.py
+++ b/tests/test_generate_report1_pending.py
@@ -62,6 +62,8 @@ def test_generate_report1_includes_pending(tmp_path, monkeypatch):
     assert pending["firstConnectEpoch"] == "1704164640"
     assert pending["lastConnectEpoch"] == "1706933100"
     assert verified["ownership"] == "службовий"
+    assert verified["informsystem"] == "none"
+    assert pending["informsystem"] == "none"
 
 
 def test_generate_report1_special_note_for_remote_types(tmp_path, monkeypatch):
@@ -115,6 +117,8 @@ def test_generate_report1_special_note_for_remote_types(tmp_path, monkeypatch):
     assert "останнє підключення – 03.02.2024 04:05." in rarm_row["note"]
     assert rmkp_row["ownership"] == ""
     assert rarm_row["ownership"] == "none"
+    assert rmkp_row["informsystem"] == "none"
+    assert rarm_row["informsystem"] == "none"
 
 
 def test_generate_report1_handles_epoch_times(tmp_path, monkeypatch):
@@ -163,6 +167,60 @@ def test_generate_report1_handles_epoch_times(tmp_path, monkeypatch):
     assert pending["firstConnectEpoch"] == "1704164640"
     assert pending["lastConnectEpoch"] == "1706933100"
     assert pending["ownership"] == "none"
+    assert rows[0]["informsystem"] == "none"
+    assert pending["informsystem"] == "none"
+
+
+def test_generate_report1_assigns_informsystem(tmp_path, monkeypatch):
+    base_dir = tmp_path
+
+    (base_dir / "configs").mkdir()
+    (base_dir / "data" / "interim").mkdir(parents=True)
+    (base_dir / "configs" / "base.yaml").write_text(
+        """devices:
+  router: "Маршрутизатор"
+""",
+        encoding="utf-8",
+    )
+
+    (base_dir / "configs" / "local.yml").write_text(
+        """apps:
+  app1:
+    source: "офіс"
+    target: "Microsoft Office"
+  app2:
+    source: "хром"
+    target: "Google Chrome"
+""",
+        encoding="utf-8",
+    )
+
+    with open(base_dir / "data" / "interim" / "verified.csv", "w", encoding="utf-8", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["source", "type", "name", "ip", "mac", "randmac", "note", "personal"])
+        writer.writerow([
+            "VS1",
+            "router",
+            "RouterName",
+            "1.1.1.1",
+            "aa",
+            "",
+            "офіс\nхром",
+            "",
+        ])
+
+    gr = importlib.import_module("scripts.generate_report1")
+    monkeypatch.setattr(gr, "BASE_DIR", base_dir)
+    gr.main()
+
+    report_path = base_dir / "data" / "result" / "report1.csv"
+    with open(report_path, encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["name"] == "Маршрутизатор\nRouterName"
+    assert row["informsystem"] == "Microsoft Office\nGoogle Chrome"
 
 
 def test_generate_report1_handles_last_date_only(tmp_path, monkeypatch):

--- a/tests/test_personal_note.py
+++ b/tests/test_personal_note.py
@@ -41,3 +41,5 @@ def test_personal_suffix_in_note(tmp_path, monkeypatch):
     )
     assert rows[0]["ownership"] == "особистий"
     assert rows[1]["ownership"] == "службовий"
+    assert rows[0]["informsystem"] == "none"
+    assert rows[1]["informsystem"] == "none"


### PR DESCRIPTION
## Summary
- add the informsystem column to report1 output and default to none when unmapped
- parse local app mappings so matched notes populate the new column instead of the name field
- update report1 generation tests to cover the new column and mapping behaviour

## Testing
- pytest tests/test_generate_report1_pending.py tests/test_personal_note.py

------
https://chatgpt.com/codex/tasks/task_e_68f60a089cfc833188652259fc22efce